### PR TITLE
each_cpp_forwarderのモジュールがない環境でも最低限の開発が行えるようにモックを実装する

### DIFF
--- a/run.py
+++ b/run.py
@@ -3,7 +3,11 @@ from pathlib import Path
 from tempfile import NamedTemporaryFile
 from typing import List
 
-import each_cpp_forwarder
+try:
+    import each_cpp_forwarder
+except:
+    from voicevox_engine.dev import each_cpp_forwarder
+
 import romkan
 import soundfile
 import uvicorn

--- a/voicevox_engine/dev/each_cpp_forwarder/__init__.py
+++ b/voicevox_engine/dev/each_cpp_forwarder/__init__.py
@@ -1,0 +1,1 @@
+from .mock import *

--- a/voicevox_engine/dev/each_cpp_forwarder/mock.py
+++ b/voicevox_engine/dev/each_cpp_forwarder/mock.py
@@ -1,0 +1,14 @@
+def initialize(*args):
+    pass
+
+
+def yukarin_s_forward(*args):
+    pass
+
+
+def yukarin_sa_forward(*args):
+    pass
+
+
+def decode_forward(*args):
+    pass


### PR DESCRIPTION
https://github.com/Hiroshiba/voicevox_engine/pull/7
の検証を行う際に必要だったため、外から見たeach_cpp_forwarderのmockを実装しました

型付けなどは厳密に行えないのでスキップし、run.pyを実行し、サーバーが立ち上がるところまでを目標としました。

このファイルの導入によりnuitkaでのビルドにどの程度の影響が出るのか確認が出来ていません。