### PR TITLE
gitignoreに追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 *.dist
 *.build
 .venv-release
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class


### PR DESCRIPTION
@isnot です。はじめまして。よろしくお願いします。

## 修正内容の説明

pythonバイトコード等の、キャッシュをコミットさせないために、除外ルールを追加します。

## この修正が必要になった背景

開発時に ```python run.py``` などと実行することがあるかと思いますが、その際に生成されるキャッシュを、gitから無視するように設定したいです。

よろしくお願いします。