### PR TITLE
フォーマッターの導入 (修正)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,13 +33,13 @@ jobs:
         id: pip-cache
         with:
           path: ${{ matrix.path }}
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt', '**/requirements-dev.txt') }}
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt', '**/requirements-test.txt') }}
           restore-keys: |
-            ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt', '**/requirements-dev.txt') }}
+            ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt', '**/requirements-test.txt') }}
 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip setuptools wheel
-          python -m pip install -r requirements.txt -r requirements-dev.txt
+          pip install -r requirements-test.txt
 
       - run: pysen run lint

--- a/README.md
+++ b/README.md
@@ -28,16 +28,11 @@ curl -s \
 ## 環境構築
 
 ```bash
-# 必要なライブラリのインストール
-pip install -r requirements.txt -r requirements-dev.txt
-```
+# 開発に必要なライブラリのインストール
+pip install -r requirements-test.txt
 
-## コードフォーマット
-
-コードのフォーマットを整えます。プルリクエストを送る前に実行してください。
-
-```bash
-pysen run format lint
+# とりあえず実行したいだけなら代わりにこちら
+pip install -r requirements.txt
 ```
 
 ## 実行
@@ -55,11 +50,21 @@ PYTHONPATH=$VOICEVOX_DIR python $CODE_DIRECTORY/run.py
 python run.py
 ```
 
+## コードフォーマット
+
+コードのフォーマットを整えます。プルリクエストを送る前に実行してください。
+
+```bash
+pysen run format lint
+```
+
 ## ビルド
 
 Build Tools for Visual Studio 2019 が必要です。
 
 ```bash
+pip install -r requirements-dev.txt
+
 python -m nuitka \
     --standalone \
     --plugin-enable=numpy \

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
+-r requirements.txt
 cython
 nuitka
 pip-licenses
-pysen[lint]

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,8 @@
+-r requirements.txt
+# from pysen's setup.py and ext/ (0.9.1)
+black>=19.10b0,<=20.8
+flake8-bugbear
+flake8>=3.7,<4
+isort>=5            #
+mypy>=0.770,<1      #
+pysen

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy
+numpy>=1.20.0       # numpy.typing support
 fastapi
 python-multipart
 uvicorn

--- a/voicevox_engine/synthesis_engine.py
+++ b/voicevox_engine/synthesis_engine.py
@@ -253,7 +253,6 @@ class SynthesisEngine:
             speaker_id=numpy.array(speaker_id, dtype=numpy.int64).reshape(-1),
         )
 
-
         phoneme_length[0] = query.prePhonemeLength
         phoneme_length[-1] = query.postPhonemeLength
         phoneme_length = numpy.round(phoneme_length * rate) / rate


### PR DESCRIPTION
#30 のマージありがとうございます。

しかし requirements-dev.txt に pip-licenses を見つけまして、ここにて tester/linter/formatter 系パッケージが詰め込まれるとリリース時に困るのでは？と思い至り、requirements-test.txt に依存パッケージを分離しました。これに伴って github actions と README.md を更新しています。

## README.md について

ビルドの記載をスクリプト的にしてみました。`build.sh` ファイルにでもして、プロジェクトディレクトリー (`voicevox_engine`) 内で実行すればビルド可能なはずです。

- Python 仮想環境として、プロジェクトディレクトリー内で `.venv-release` が既に使われていると上書きするのでご注意ください。
- そもそも音声ライブラリ本体がないので正しいか怪しいですが・・・。変数にした `VOICEVOX_CORE_DIR` の二行を削除してやることでビルドは可能です。
- pip-licenses もついでに実行して `pip-licenses.json` を出力しますが、これで実用にあっていますか？
