### PR TITLE
requirements-dev.txt からテスト用パッケージを分離

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,13 +33,13 @@ jobs:
         id: pip-cache
         with:
           path: ${{ matrix.path }}
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt', '**/requirements-dev.txt') }}
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt', '**/requirements-test.txt') }}
           restore-keys: |
-            ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt', '**/requirements-dev.txt') }}
+            ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt', '**/requirements-test.txt') }}
 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip setuptools wheel
-          python -m pip install -r requirements.txt -r requirements-dev.txt
+          pip install -r requirements-test.txt
 
       - run: pysen run lint

--- a/README.md
+++ b/README.md
@@ -28,16 +28,11 @@ curl -s \
 ## 環境構築
 
 ```bash
-# 必要なライブラリのインストール
-pip install -r requirements.txt -r requirements-dev.txt
-```
+# 開発に必要なライブラリのインストール
+pip install -r requirements-test.txt
 
-## コードフォーマット
-
-コードのフォーマットを整えます。プルリクエストを送る前に実行してください。
-
-```bash
-pysen run format lint
+# とりあえず実行したいだけなら代わりにこちら
+pip install -r requirements.txt
 ```
 
 ## 実行
@@ -55,11 +50,21 @@ PYTHONPATH=$VOICEVOX_DIR python $CODE_DIRECTORY/run.py
 python run.py
 ```
 
+## コードフォーマット
+
+コードのフォーマットを整えます。プルリクエストを送る前に実行してください。
+
+```bash
+pysen run format lint
+```
+
 ## ビルド
 
 Build Tools for Visual Studio 2019 が必要です。
 
 ```bash
+pip install -r requirements-dev.txt
+
 python -m nuitka \
     --standalone \
     --plugin-enable=numpy \

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
+-r requirements.txt
 cython
 nuitka
 pip-licenses
-pysen[lint]

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,2 @@
+-r requirements.txt
+pysen[lint]


### PR DESCRIPTION
#34 の再 PR になります。

> #30 の後で requirements-dev.txt に pip-licenses を見つけまして、ここにて tester/linter/formatter 系パッケージが詰め込まれるとリリース時に困るのでは？と思い至り、requirements-test.txt に依存パッケージを分離しました。これに伴って github actions と README.md を更新しています。

@Hiroshiba レビューいただきましてありがとうございました。２度手間になりすみません。

無駄な挑戦を放り込んでしまっていたようなのでビルド回りは取り下げて話を単純にしました。