### PR TITLE
Mock を呼んでもエラーが出ないようにした

### DIFF
--- a/voicevox_engine/dev/each_cpp_forwarder/mock.py
+++ b/voicevox_engine/dev/each_cpp_forwarder/mock.py
@@ -1,14 +1,32 @@
-def initialize(*args):
+from logging import getLogger
+from typing import Any, Dict, List
+
+import numpy as np
+
+
+def initialize(*args: List[Any]) -> None:
     pass
 
 
-def yukarin_s_forward(*args):
-    pass
+def yukarin_s_forward(length: int, **kwargs: Dict[str, Any]) -> np.ndarray:
+    logger = getLogger("uvicorn")  # FastAPI / Uvicorn 内からの利用のため
+    logger.info(
+        "Sorry, yukarin_s_forward() is a mock. Return values are incorrect.",
+    )
+    return np.ones(length) / 5
 
 
-def yukarin_sa_forward(*args):
-    pass
+def yukarin_sa_forward(length: int, **kwargs: Dict[str, Any]) -> np.ndarray:
+    logger = getLogger("uvicorn")  # FastAPI / Uvicorn 内からの利用のため
+    logger.info(
+        "Sorry, yukarin_sa_forward() is a mock. Return values are incorrect.",
+    )
+    return np.ones((1, length)) * 5
 
 
-def decode_forward(*args):
-    pass
+def decode_forward(length: int, **kwargs: Dict[str, Any]) -> np.ndarray:
+    logger = getLogger("uvicorn")  # FastAPI / Uvicorn 内からの利用のため
+    logger.info(
+        "Sorry, decode_forward() is a mock. Return values are incorrect.",
+    )
+    return np.ones(length * 256)


### PR DESCRIPTION
製品版音声ライブラリーなしに起動して、API を実行した際にエラーが出ることを解消しました。
あくまでそれっぽい値の適当な長さの配列を返すだけで、音声合成はできません。

音声の評価には使えませんが、その他のテスト、デバッグに役立つようなら幸いです。

<details>
<summary>エンジンの実行時ログ</summary>

```bash
$ python run.py
Notice: mock-library will be used. Try re-run with valid --voicevox_dir
INFO:     Started server process [12692]
INFO:     Waiting for application startup.
INFO:     Application startup complete.
INFO:     Uvicorn running on http://127.0.0.1:50021 (Press CTRL+C to quit)
INFO:     Sorry, yukarin_s_forward() is a mock. Return values are incorrect.
INFO:     Sorry, yukarin_sa_forward() is a mock. Return values are incorrect.
INFO:     127.0.0.1:50713 - "POST /audio_query?text=%E3%81%93%E3%82%93%E3%81%AB%E3%81%A1%E3%82%8F&speaker=0 HTTP/1.1" 200 OK
INFO:     Sorry, decode_forward() is a mock. Return values are incorrect.
INFO:     127.0.0.1:50714 - "POST /synthesis?speaker=0 HTTP/1.1" 200 OK
```

</details>