### PR TITLE
母音が無声化されるモーラもテキストへ変換できるようにする

### DIFF
--- a/run.py
+++ b/run.py
@@ -74,9 +74,14 @@ def make_synthesis_engine(
 
 
 def mora_to_text(mora: str) -> str:
-    if mora.lower() in openjtalk_mora2text:
+    if mora in openjtalk_mora2text:
+        # 通常の子音と母音、あるいは「ん」"N"
+        return openjtalk_mora2text[mora]
+    elif mora.lower() in openjtalk_mora2text:
+        # 無声化される母音 ["A", "I", "U", "E", "O"] を含む
         return openjtalk_mora2text[mora.lower()]
     else:
+        # 既知のモーラでない
         return mora
 
 

--- a/run.py
+++ b/run.py
@@ -73,9 +73,9 @@ def make_synthesis_engine(
     )
 
 
-def mora_to_text(mora: str):
-    if mora in openjtalk_mora2text:
-        return openjtalk_mora2text[mora]
+def mora_to_text(mora: str) -> str:
+    if mora.lower() in openjtalk_mora2text:
+        return openjtalk_mora2text[mora.lower()]
     else:
         return mora
 


### PR DESCRIPTION
## 問題
「おはようございます」などを /audio_query した結果で、テキストの最後が "ス" でなく "sU" となる。

## 対応
無声化される母音は大文字表記 "A", "I", "U", "E", "O" になるので、lowercase をとればモーラ辞書から引くことができる。