### PR TITLE
[Mock] /synthesis で、雑音（無音？）の代わりに、固定のダミー・テキストを読み上げる #27

### DIFF
--- a/voicevox_engine/dev/core/mock.py
+++ b/voicevox_engine/dev/core/mock.py
@@ -30,6 +30,7 @@ def yukarin_sa_forward(length: int, **kwargs: Dict[str, Any]) -> np.ndarray:
 
 def decode_forward(length: int, **kwargs: Dict[str, Any]) -> np.ndarray:
     """
+    合成音声の波形データをNumPy配列で返します。ただし、常に固定の文言を読み上げます（DUMMY_TEXT）
     参照→SynthesisEngine のdocstring [Mock]
 
     Parameters
@@ -45,6 +46,7 @@ def decode_forward(length: int, **kwargs: Dict[str, Any]) -> np.ndarray:
     Note
     -------
         ここで行う音声合成では、調声（ピッチ等）を反映しない
+        また、入力内容によらず常に固定の文言を読み上げる
 
         # pyopenjtalk.tts()の出力仕様
         dtype=np.float64, 16 bit, mono 48000 Hz


### PR DESCRIPTION
一行要約：このPRはたぶんいらない

core （旧：each_cpp_forwarder）のMockを使用している時、
/synthesis APIへのリクエストから返ってくる音声データを再生すると、何か「ブチ、プツッ」といったような雑音が聞こえました（環境依存の可能性あり）。
Mock実装を見ると、適当なNumPy配列を生成しており、ここで生成されるデータに特に意味はないのかもしれません。
合成音声をしたいエンドユーザーには関係なく、開発者しか遭遇しない事柄ですが、（この雑音は）個人的にはあまり好ましいとは言えないのかと感じています。

そこで、私は以前にpyopenjtalkを利用した（旧：each_cpp_forwarderの）Mockを試行しましたが、 @Hiroshiba さんのアドバイスがあり、それは取りやめました。

本PRでは、以前の試行における欠点を解消して、純粋にMockの中で完結できる実装のみを使い、かつ聞いた時に意味のある音声を再生することを目指します。

別の手法として、pyopenjtalkを使わず、ダミーの音声をwavファイルで保持してそれをロード、利用することが考えられます。その場合には、多少とはいえ（100KiB程度か？）配布パッケージの容量増加があります。

本PR全体を通して、そこまでする必要あるのか？という点が検討課題と思われます。