### PR TITLE
[Mock] SynthesisEngineの率直なMock ref. #27

### DIFF
--- a/run.py
+++ b/run.py
@@ -44,13 +44,13 @@ def make_synthesis_engine(
         if voicevox_dir.exists():
             sys.path.insert(0, str(voicevox_dir))
 
-    disable_core = False
+    has_voicevox_core = True
     try:
         import core
     except ImportError:
         from voicevox_engine.dev import core
 
-        disable_core = True
+        has_voicevox_core = False
 
         # 音声ライブラリの Python モジュールをロードできなかった
         print(
@@ -63,19 +63,19 @@ def make_synthesis_engine(
 
     core.initialize(voicelib_dir.as_posix() + "/", use_gpu)
 
-    if disable_core:
-        from voicevox_engine.dev.synthesis_engine import (
-            SynthesisEngine as mock_synthesis_engine,
+    if has_voicevox_core:
+        return SynthesisEngine(
+            yukarin_s_forwarder=core.yukarin_s_forward,
+            yukarin_sa_forwarder=core.yukarin_sa_forward,
+            decode_forwarder=core.decode_forward,
         )
 
-        # モックで置き換える
-        return mock_synthesis_engine()
-
-    return SynthesisEngine(
-        yukarin_s_forwarder=core.yukarin_s_forward,
-        yukarin_sa_forwarder=core.yukarin_sa_forward,
-        decode_forwarder=core.decode_forward,
+    from voicevox_engine.dev.synthesis_engine import (
+        SynthesisEngine as mock_synthesis_engine,
     )
+
+    # モックで置き換える
+    return mock_synthesis_engine()
 
 
 def mora_to_text(mora: str):

--- a/run.py
+++ b/run.py
@@ -44,10 +44,13 @@ def make_synthesis_engine(
         if voicevox_dir.exists():
             sys.path.insert(0, str(voicevox_dir))
 
+    disable_core = False
     try:
         import core
     except ImportError:
         from voicevox_engine.dev import core
+
+        disable_core = True
 
         # 音声ライブラリの Python モジュールをロードできなかった
         print(
@@ -59,6 +62,14 @@ def make_synthesis_engine(
         voicelib_dir = Path(__file__).parent  # core.__file__だとnuitkaビルド後にエラー
 
     core.initialize(voicelib_dir.as_posix() + "/", use_gpu)
+
+    if disable_core:
+        from voicevox_engine.dev.synthesis_engine import (
+            SynthesisEngine as mock_synthesis_engine,
+        )
+
+        # モックで置き換える
+        return mock_synthesis_engine()
 
     return SynthesisEngine(
         yukarin_s_forwarder=core.yukarin_s_forward,

--- a/voicevox_engine/dev/synthesis_engine/__init__.py
+++ b/voicevox_engine/dev/synthesis_engine/__init__.py
@@ -1,0 +1,3 @@
+from .mock import SynthesisEngine
+
+__all__ = ["SynthesisEngine"]

--- a/voicevox_engine/dev/synthesis_engine/mock.py
+++ b/voicevox_engine/dev/synthesis_engine/mock.py
@@ -1,0 +1,126 @@
+from logging import getLogger
+from typing import Any, Dict, List
+
+import numpy as np
+from pyopenjtalk import tts
+from resampy import resample
+
+from voicevox_engine.model import AccentPhrase, AudioQuery
+from voicevox_engine.synthesis_engine import to_flatten_moras
+
+
+class SynthesisEngine():
+    """
+    SynthesisEngine [Mock]
+    """
+    def __init__(self, **kwargs):
+        """
+        __init__ [Mock]
+        """
+        super().__init__()
+
+    def replace_phoneme_length(
+        self, accent_phrases: List[AccentPhrase], speaker_id: int
+    ) -> List[AccentPhrase]:
+        """
+        replace_phoneme_length 入力accent_phrasesを変更せずにそのまま返します [Mock]
+
+        Parameters
+        ----------
+        accent_phrases : List[AccentPhrase]
+            フレーズ句のリスト
+        speaker_id : int
+            話者
+
+        Returns
+        -------
+        List[AccentPhrase]
+            フレーズ句のリスト（変更なし）
+        """
+        return accent_phrases
+
+    def replace_mora_pitch(
+        self, accent_phrases: List[AccentPhrase], speaker_id: int
+    ) -> List[AccentPhrase]:
+        """
+        replace_mora_pitch 入力accent_phrasesを変更せずにそのまま返します [Mock]
+
+        Parameters
+        ----------
+        accent_phrases : List[AccentPhrase]
+            フレーズ句のリスト
+        speaker_id : int
+            話者
+
+        Returns
+        -------
+        List[AccentPhrase]
+            フレーズ句のリスト（変更なし）
+        """
+        return accent_phrases
+
+    def synthesis(self, query: AudioQuery, speaker_id: int) -> np.ndarray:
+        """
+        synthesis voicevox coreを使わずに、音声合成する [Mock]
+
+        Parameters
+        ----------
+        query : AudioQuery
+            /audio_query APIで得たjson
+        speaker_id : int
+            話者
+
+        Returns
+        -------
+        wave [np.ndarray]
+            音声波形データをNumPy配列で返します
+        """
+        # recall text in katakana
+        flatten_moras = to_flatten_moras(query.accent_phrases)
+        kana_text = "".join([mora.text for mora in flatten_moras])
+
+        wave = self.forward(kana_text)
+
+        # volume
+        if query.volumeScale != 1:
+            wave *= query.volumeScale
+
+        return wave
+
+    def forward(self, text: str, **kwargs: Dict[str, Any]) -> np.ndarray:
+        """
+        decode_forward tts via pyopenjtalk.tts()
+        参照→SynthesisEngine のdocstring [Mock]
+
+        Parameters
+        ----------
+        text : str
+            入力文字列（例：読み上げたい文章をカタカナにした文字列、等）
+
+        Returns
+        -------
+        wave [np.ndarray]
+            音声波形データをNumPy配列で返します
+
+        Note
+        -------
+        ここで行う音声合成では、調声（ピッチ等）を反映しない
+
+        # pyopenjtalk.tts()の出力仕様
+        dtype=np.float64, 16 bit, mono 48000 Hz
+
+        # resampleの説明
+        本来はfloat64の入力でも問題ないのかと思われたが、実際には出力が音割れひどかった。
+        対策として、あらかじめint16に型変換しておくと、期待通りの結果になった。
+        非モック実装（decode_forward）と合わせるために、出力を24kHzに変換した。
+        """
+        logger = getLogger("uvicorn")  # FastAPI / Uvicorn 内からの利用のため
+        logger.info("[Mock] input text: %s" % text)
+        wave, sr = tts(text)
+        wave = resample(
+            wave.astype("int16"),
+            sr,
+            24000,
+            filter="kaiser_fast",
+        )
+        return wave

--- a/voicevox_engine/dev/synthesis_engine/mock.py
+++ b/voicevox_engine/dev/synthesis_engine/mock.py
@@ -9,10 +9,11 @@ from voicevox_engine.model import AccentPhrase, AudioQuery
 from voicevox_engine.synthesis_engine import to_flatten_moras
 
 
-class SynthesisEngine():
+class SynthesisEngine:
     """
     SynthesisEngine [Mock]
     """
+
     def __init__(self, **kwargs):
         """
         __init__ [Mock]

--- a/voicevox_engine/dev/synthesis_engine/mock.py
+++ b/voicevox_engine/dev/synthesis_engine/mock.py
@@ -2,6 +2,7 @@ from logging import getLogger
 from typing import Any, Dict, List
 
 import numpy as np
+import numpy.typing as npt
 from pyopenjtalk import tts
 from resampy import resample
 
@@ -60,7 +61,7 @@ class SynthesisEngine:
         """
         return accent_phrases
 
-    def synthesis(self, query: AudioQuery, speaker_id: int) -> np.ndarray:
+    def synthesis(self, query: AudioQuery, speaker_id: int) -> npt.NDArray[np.int16]:
         """
         synthesis voicevox coreを使わずに、音声合成する [Mock]
 
@@ -73,7 +74,7 @@ class SynthesisEngine:
 
         Returns
         -------
-        wave [np.ndarray]
+        wave [npt.NDArray[np.int16]]
             音声波形データをNumPy配列で返します
         """
         # recall text in katakana
@@ -86,11 +87,11 @@ class SynthesisEngine:
         if query.volumeScale != 1:
             wave *= query.volumeScale
 
-        return wave
+        return wave.astype("int16")
 
-    def forward(self, text: str, **kwargs: Dict[str, Any]) -> np.ndarray:
+    def forward(self, text: str, **kwargs: Dict[str, Any]) -> npt.NDArray[np.int16]:
         """
-        decode_forward tts via pyopenjtalk.tts()
+        forward tts via pyopenjtalk.tts()
         参照→SynthesisEngine のdocstring [Mock]
 
         Parameters
@@ -100,7 +101,7 @@ class SynthesisEngine:
 
         Returns
         -------
-        wave [np.ndarray]
+        wave [npt.NDArray[np.int16]]
             音声波形データをNumPy配列で返します
 
         Note
@@ -124,4 +125,4 @@ class SynthesisEngine:
             24000,
             filter="kaiser_fast",
         )
-        return wave
+        return wave.astype("int16")


### PR DESCRIPTION
ref #27

@Hiroshiba さんの要請にあった、SynthesisEngineのモックを実装してみました。

## 開発の過程で苦労した点

run.py の中で SynthesisEngineのモック を Mock ですげ替える部分で試行錯誤がありました。
当初はTypeチェックをすり抜けるために、Python標準？のmock.patchの機構を使うことを考えましたが、私の力不足で、動く実装に落とし込めませんでした。
そこでそのようなトリックなしに、単純に入れ替え済みのインスタンスを使うような実装にしました。
簡単に試した範囲で動作上は問題は見られませんでした。

## 私的な意見

個人的な印象に基づく話で恐縮ですが、今回の私の実装手法は、その場しのぎのツギハギという感じがします。
「Mock」という観点だけではなく、VOICEVOXコアに依存しない音声合成、そして利用の制限がより緩い音声データを使える実装として、意味があるのではないかと考えています。（あえて本実装を使うという選択肢）

エンジンを全体的にpluggableな構造にして、部分毎に実装を入れ替え可能なようにして、その一環の中でSynthesisEngineを入れ替えるようなやり方が望ましいのだろうなぁと思いました。
しかし今回はたぶん望まれてないと思ったので、それは見送りました。