### PR TITLE
numpy 1.20 で通る型付けにする

### DIFF
--- a/voicevox_engine/dev/synthesis_engine/mock.py
+++ b/voicevox_engine/dev/synthesis_engine/mock.py
@@ -2,7 +2,6 @@ from logging import getLogger
 from typing import Any, Dict, List
 
 import numpy as np
-import numpy.typing as npt
 from pyopenjtalk import tts
 from resampy import resample
 
@@ -61,7 +60,7 @@ class SynthesisEngine:
         """
         return accent_phrases
 
-    def synthesis(self, query: AudioQuery, speaker_id: int) -> npt.NDArray[np.int16]:
+    def synthesis(self, query: AudioQuery, speaker_id: int) -> np.ndarray:
         """
         synthesis voicevox coreを使わずに、音声合成する [Mock]
 
@@ -89,7 +88,7 @@ class SynthesisEngine:
 
         return wave.astype("int16")
 
-    def forward(self, text: str, **kwargs: Dict[str, Any]) -> npt.NDArray[np.int16]:
+    def forward(self, text: str, **kwargs: Dict[str, Any]) -> np.ndarray:
         """
         forward tts via pyopenjtalk.tts()
         参照→SynthesisEngine のdocstring [Mock]


### PR DESCRIPTION
fix #79

numpy の型アノテーションについて

- 環境の numpy が `1.21` 以降のとき mypy のチェックは `numpy.ndarray` 型を `numpy.typing.NDArray` で書くように指摘する。
- 環境の numpy が `1.20` 以前のとき、numpy.typing に NDArray はないが、mypy も ndarray 型に指摘をしない (はず)。

現在のところ、このプロジェクトは numpy 1.20 を使っているので、`numpy.typing.NDArray` を外しておく。
(resampy で numba が必要とされ、numba の現時点のバージョン 0.54 では numpy 1.21 をサポートしてない)