### PR TITLE
音素化されないテキスト入力に対応

### DIFF
--- a/run.py
+++ b/run.py
@@ -130,6 +130,9 @@ def generate_app(engine: SynthesisEngine) -> FastAPI:
             return []
 
         utterance = extract_full_context_label(text)
+        if utterance.breath_groups == []:
+            return []
+
         return replace_mora_data(
             accent_phrases=[
                 AccentPhrase(

--- a/run.py
+++ b/run.py
@@ -130,7 +130,7 @@ def generate_app(engine: SynthesisEngine) -> FastAPI:
             return []
 
         utterance = extract_full_context_label(text)
-        if utterance.breath_groups == []:
+        if len(utterance.breath_groups) == 0:
             return []
 
         return replace_mora_data(


### PR DESCRIPTION
fix #80

入力テキストが発声できない文字のみの場合、`extract_full_context_label` は空のリストを持つ `Utterance` を戻す。空のリストを後の処理に流すと問題になる。
テキストに音素が含まれるとみなすかどうかは pyopenjtalk およびその内側の処理に依存しているので、エンジン側で結果を確認する。