### PR TITLE
coreモジュールのimport失敗時にスタックトレースを表示する

### DIFF
--- a/run.py
+++ b/run.py
@@ -57,6 +57,7 @@ def make_synthesis_engine(
         import core
     except ImportError:
         import traceback
+
         from voicevox_engine.dev import core
 
         has_voicevox_core = False

--- a/run.py
+++ b/run.py
@@ -56,11 +56,16 @@ def make_synthesis_engine(
     try:
         import core
     except ImportError:
+        import traceback
         from voicevox_engine.dev import core
 
         has_voicevox_core = False
 
         # 音声ライブラリの Python モジュールをロードできなかった
+        print(
+            traceback.format_exc(),
+            file=sys.stderr,
+        )
         print(
             "Notice: mock-library will be used. Try re-run with valid --voicevox_dir",  # noqa
             file=sys.stderr,

--- a/run.py
+++ b/run.py
@@ -62,10 +62,7 @@ def make_synthesis_engine(
         has_voicevox_core = False
 
         # 音声ライブラリの Python モジュールをロードできなかった
-        print(
-            traceback.format_exc(),
-            file=sys.stderr,
-        )
+        traceback.print_exc()
         print(
             "Notice: mock-library will be used. Try re-run with valid --voicevox_dir",  # noqa
             file=sys.stderr,


### PR DESCRIPTION
共有ライブラリの不足やパスの設定ミス時に原因が表示されないのが不便です。

`import core`失敗時に、ImportErrorのスタックトレースを標準エラー出力に出力するようにします。

## 備考
`core`が存在しないためにImportに失敗したのか（Mockを積極的に使いたい環境）、`core`内部でエラーが発生したためにImportに失敗したのか（`voicevox_engine`を`core`を使って動かしたい環境）の判別をしていませんが、可能ならしたほうがいいかもしれないです。

## 例：LibTorchの不足

### 変更前

```
$  python3 run.py --voicevox_dir /opt/voicevox_core/ --voicelib_dir /opt/voicevox_core/ --host 0.0.0.0
Notice: --voicevox_dir is /opt/voicevox_core
Notice: mock-library will be used. Try re-run with valid --voicevox_dir
INFO:     Started server process [589]
INFO:     Waiting for application startup.
INFO:     Application startup complete.
INFO:     Uvicorn running on http://0.0.0.0:50021 (Press CTRL+C to quit)
```

### 変更後

```
$ python3 run.py --voicevox_dir /opt/voicevox_core/ --voicelib_dir /opt/voicevox_core/ --host 0.0.0.0
Notice: --voicevox_dir is /opt/voicevox_core
Traceback (most recent call last):
  File "run.py", line 57, in make_synthesis_engine
    import core
ImportError: libc10.so: cannot open shared object file: No such file or directory

Notice: mock-library will be used. Try re-run with valid --voicevox_dir
INFO:     Started server process [36]
INFO:     Waiting for application startup.
INFO:     Application startup complete.
INFO:     Uvicorn running on http://0.0.0.0:50021 (Press CTRL+C to quit)
```

（`libc10.so`はLibTorchに同梱されている）
