### PR TITLE
Dockerfile (Linux)・GitHub Actionsによる自動pushの追加 #84

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -68,12 +68,6 @@ jobs:
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new
 
-      - name: Update Docker Hub description with README.md
-        uses: peter-evans/dockerhub-description@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
       # https://evilmartians.com/chronicles/build-images-on-github-actions-with-docker-layer-caching
       - name: Move cache (reduce cache size)
         run: |

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -52,14 +52,6 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Cache Docker layers
-        uses: actions/cache@v2
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ matrix.tag || 'latest' }}-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-${{ matrix.tag || 'latest' }}
-
       - name: Build and Deploy Docker image
         uses: docker/build-push-action@v2
         env:
@@ -83,10 +75,5 @@ jobs:
           tags: |
             ${{ env.IMAGE_TAG }}
             ${{ env.VERSIONED_IMAGE_TAG }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,mode=max,dest=/tmp/.buildx-cache-new
-
-      - name: Move cache (reduce cache size)
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+          cache-from: type=registry,ref=${{ env.IMAGE_TAG }}-buildcache
+          cache-to: type=registry,ref=${{ env.IMAGE_TAG }}-buildcache,mode=max

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -72,13 +72,7 @@ jobs:
           push: true
           tags: ${{ env.IMAGE_NAME }}:${{ matrix.tag }}
           cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new
-
-      # https://evilmartians.com/chronicles/build-images-on-github-actions-with-docker-layer-caching
-      - name: Move cache (reduce cache size)
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+          cache-to: type=local,mode=max,dest=/tmp/.buildx-cache-new
 
       - name: Build and Deploy versioned Docker image
         if: success() && github.event.release.tag_name != ''
@@ -92,8 +86,8 @@ jobs:
           target: ${{ matrix.target }}
           push: true
           tags: ${{ env.IMAGE_NAME }}:${{ (matrix.tag == 'latest' && '') || matrix.tag }}${{ (matrix.tag == 'latest' && '') || '-' }}${{ github.event.release.tag_name }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new
+          cache-from: type=local,src=/tmp/.buildx-cache-new
+          cache-to: type=local,mode=max,dest=/tmp/.buildx-cache-new
 
       - name: Move cache (reduce cache size)
         run: |

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -70,7 +70,7 @@ jobs:
             BASE_RUNTIME_IMAGE=${{ matrix.base_runtime_image }}
           target: ${{ matrix.target }}
           push: true
-          tags: ${{ env.IMAGE_NAME }}:${{ matrix.tag }}-latest
+          tags: ${{ env.IMAGE_NAME }}:${{ matrix.tag }}${{ (matrix.tag == 'latest' && '') || '-' }}latest
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,mode=max,dest=/tmp/.buildx-cache-new
 
@@ -85,7 +85,7 @@ jobs:
             BASE_RUNTIME_IMAGE=${{ matrix.base_runtime_image }}
           target: ${{ matrix.target }}
           push: true
-          tags: ${{ env.IMAGE_NAME }}:${{ matrix.tag }}-${{ github.event.release.tag_name }}
+          tags: ${{ env.IMAGE_NAME }}:${{ matrix.tag }}${{ (matrix.tag == 'latest' && '') || '-' }}${{ github.event.release.tag_name }}
           cache-from: type=local,src=/tmp/.buildx-cache-new
           cache-to: type=local,mode=max,dest=/tmp/.buildx-cache-new
 

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -56,9 +56,9 @@ jobs:
         uses: actions/cache@v2
         with:
           path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          key: ${{ runner.os }}-buildx-${{ matrix.base_runtime_image }}-${{ github.sha }}
           restore-keys: |
-            ${{ runner.os }}-buildx
+            ${{ runner.os }}-buildx-${{ matrix.base_runtime_image }}
 
       - name: Build and Deploy Docker image
         uses: docker/build-push-action@v2

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -85,7 +85,7 @@ jobs:
             BASE_RUNTIME_IMAGE=${{ matrix.base_runtime_image }}
           target: ${{ matrix.target }}
           push: true
-          tags: ${{ env.IMAGE_NAME }}:${{ github.event.release.tag_name }}${{ (matrix.tag == 'latest' && '') || '-' }}${{ (matrix.tag == 'latest' && '') || matrix.tag }}
+          tags: ${{ env.IMAGE_NAME }}:${{ (matrix.tag == 'latest' && '') || matrix.tag }}${{ (matrix.tag == 'latest' && '') || '-' }}${{ github.event.release.tag_name }}
           cache-from: type=local,src=/tmp/.buildx-cache-new
           cache-to: type=local,mode=max,dest=/tmp/.buildx-cache-new
 

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -70,7 +70,7 @@ jobs:
             BASE_RUNTIME_IMAGE=${{ matrix.base_runtime_image }}
           target: ${{ matrix.target }}
           push: true
-          tags: ${{ env.IMAGE_NAME }}:${{ matrix.tag }}${{ (matrix.tag == 'latest' && '') || '-' }}latest
+          tags: ${{ env.IMAGE_NAME }}:${{ matrix.tag }}${{ (matrix.tag == '' && '') || '-' }}latest
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,mode=max,dest=/tmp/.buildx-cache-new
 
@@ -85,7 +85,7 @@ jobs:
             BASE_RUNTIME_IMAGE=${{ matrix.base_runtime_image }}
           target: ${{ matrix.target }}
           push: true
-          tags: ${{ env.IMAGE_NAME }}:${{ matrix.tag }}${{ (matrix.tag == 'latest' && '') || '-' }}${{ github.event.release.tag_name }}
+          tags: ${{ env.IMAGE_NAME }}:${{ matrix.tag }}${{ (matrix.tag == '' && '') || '-' }}${{ github.event.release.tag_name }}
           cache-from: type=local,src=/tmp/.buildx-cache-new
           cache-to: type=local,mode=max,dest=/tmp/.buildx-cache-new
 

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            tag: latest
+            tag: ''
             target: runtime-env
             base_runtime_image: ubuntu:focal
           - os: ubuntu-latest
@@ -70,7 +70,7 @@ jobs:
             BASE_RUNTIME_IMAGE=${{ matrix.base_runtime_image }}
           target: ${{ matrix.target }}
           push: true
-          tags: ${{ env.IMAGE_NAME }}:${{ matrix.tag }}
+          tags: ${{ env.IMAGE_NAME }}:${{ matrix.tag }}-latest
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,mode=max,dest=/tmp/.buildx-cache-new
 
@@ -85,7 +85,7 @@ jobs:
             BASE_RUNTIME_IMAGE=${{ matrix.base_runtime_image }}
           target: ${{ matrix.target }}
           push: true
-          tags: ${{ env.IMAGE_NAME }}:${{ (matrix.tag == 'latest' && '') || matrix.tag }}${{ (matrix.tag == 'latest' && '') || '-' }}${{ github.event.release.tag_name }}
+          tags: ${{ env.IMAGE_NAME }}:${{ matrix.tag }}-${{ github.event.release.tag_name }}
           cache-from: type=local,src=/tmp/.buildx-cache-new
           cache-to: type=local,mode=max,dest=/tmp/.buildx-cache-new
 

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -85,7 +85,7 @@ jobs:
             BASE_RUNTIME_IMAGE=${{ matrix.base_runtime_image }}
           target: ${{ matrix.target }}
           push: true
-          tags: ${{ env.IMAGE_NAME }}:${{ (matrix.tag == 'latest' && github.event.release.tag_name) || (join([matrix.tag, github.event.release.tag_name], '-') }}
+          tags: ${{ env.IMAGE_NAME }}:${{ (matrix.tag == 'latest' && '') || '${{ matrix.tag }}-' }}${{ github.event.release.tag_name }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new
 

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -74,6 +74,12 @@ jobs:
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new
 
+      # https://evilmartians.com/chronicles/build-images-on-github-actions-with-docker-layer-caching
+      - name: Move cache (reduce cache size)
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+
       - name: Build and Deploy versioned Docker image
         if: success() && github.event.release.tag_name != ''
         uses: docker/build-push-action@v2
@@ -89,7 +95,6 @@ jobs:
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new
 
-      # https://evilmartians.com/chronicles/build-images-on-github-actions-with-docker-layer-caching
       - name: Move cache (reduce cache size)
         run: |
           rm -rf /tmp/.buildx-cache

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -20,18 +20,23 @@ jobs:
         include:
           - os: ubuntu-latest
             tag: latest
+            target: runtime-env
             base_runtime_image: ubuntu:focal
           - os: ubuntu-latest
             tag: cpu-latest
+            target: runtime-env
             base_runtime_image: ubuntu:focal
           - os: ubuntu-latest
             tag: cpu-ubuntu20.04
+            target: runtime-env
             base_runtime_image: ubuntu:focal
           - os: ubuntu-latest
             tag: nvidia-latest
+            target: runtime-nvidia-env
             base_runtime_image: nvidia/cuda:11.4.1-cudnn8-runtime-ubuntu20.04
           - os: ubuntu-latest
             tag: nvidia-ubuntu20.04
+            target: runtime-nvidia-env
             base_runtime_image: nvidia/cuda:11.4.1-cudnn8-runtime-ubuntu20.04
 
     steps:
@@ -63,6 +68,7 @@ jobs:
           file: ./Dockerfile
           build-args: |
             BASE_RUNTIME_IMAGE=${{ matrix.base_runtime_image }}
+          target: ${{ matrix.target }}
           push: true
           tags: ${{ env.IMAGE_NAME }}:${{ matrix.tag }}
           cache-from: type=local,src=/tmp/.buildx-cache

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -2,7 +2,7 @@ name: build-docker
 on:
   push:
     branches:
-      # - master
+      - master
   release:
     types:
       - created

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -23,7 +23,7 @@ jobs:
             target: runtime-env
             base_runtime_image: ubuntu:focal
           - os: ubuntu-latest
-            tag: cpu-latest
+            tag: cpu
             target: runtime-env
             base_runtime_image: ubuntu:focal
           - os: ubuntu-latest
@@ -31,7 +31,7 @@ jobs:
             target: runtime-env
             base_runtime_image: ubuntu:focal
           - os: ubuntu-latest
-            tag: nvidia-latest
+            tag: nvidia
             target: runtime-nvidia-env
             base_runtime_image: nvidia/cuda:11.4.1-cudnn8-runtime-ubuntu20.04
           - os: ubuntu-latest
@@ -71,6 +71,21 @@ jobs:
           target: ${{ matrix.target }}
           push: true
           tags: ${{ env.IMAGE_NAME }}:${{ matrix.tag }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new
+
+      - name: Build and Deploy versioned Docker image
+        if: success() && github.event.release.tag_name != ''
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          builder: ${{ steps.buildx.outputs.name }}
+          file: ./Dockerfile
+          build-args: |
+            BASE_RUNTIME_IMAGE=${{ matrix.base_runtime_image }}
+          target: ${{ matrix.target }}
+          push: true
+          tags: ${{ env.IMAGE_NAME }}:${{ (matrix.tag == 'latest' && github.event.release.tag_name) || (join([matrix.tag, github.event.release.tag_name], '-') }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new
 

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -1,8 +1,8 @@
 name: build-docker
 on:
   push:
-    # branches:
-    #   - master
+    branches:
+      - master
   release:
     types:
       - created
@@ -85,7 +85,7 @@ jobs:
             BASE_RUNTIME_IMAGE=${{ matrix.base_runtime_image }}
           target: ${{ matrix.target }}
           push: true
-          tags: ${{ env.IMAGE_NAME }}:${{ (matrix.tag == 'latest' && '') || '${{ matrix.tag }}-' }}${{ github.event.release.tag_name }}
+          tags: ${{ env.IMAGE_NAME }}:${{ (matrix.tag == 'latest' && '') || matrix.tag }}${{ (matrix.tag == 'latest' && '') || '-' }}${{ github.event.release.tag_name }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new
 

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -1,0 +1,75 @@
+name: build-docker
+on:
+  push:
+    # branches:
+    #   - master
+  release:
+    types:
+      - created
+
+jobs:
+  build-docker:
+    runs-on: ${{ matrix.os }}
+
+    env:
+      IMAGE_NAME: ${{ secrets.DOCKERHUB_USERNAME }}/voicevox_engine
+      # IMAGE_NAME: voicevox/voicevox_engine
+
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            tag: latest
+            base_runtime_image: ubuntu:focal
+          - os: ubuntu-latest
+            tag: cpu-latest
+            base_runtime_image: ubuntu:focal
+          - os: ubuntu-latest
+            tag: cpu-ubuntu20.04
+            base_runtime_image: ubuntu:focal
+          - os: ubuntu-latest
+            tag: nvidia-latest
+            base_runtime_image: nvidia/cuda:11.4.1-cudnn8-runtime-ubuntu20.04
+          - os: ubuntu-latest
+            tag: nvidia-ubuntu20.04
+            base_runtime_image: nvidia/cuda:11.4.1-cudnn8-runtime-ubuntu20.04
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx
+
+      - name: Build and Deploy Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          builder: ${{ steps.buildx.outputs.name }}
+          file: ./Dockerfile
+          build-args: |
+            BASE_RUNTIME_IMAGE=${{ matrix.base_runtime_image }}
+          push: true
+          tags: ${{ env.IMAGE_NAME }}:${{ matrix.tag }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new
+
+      # https://evilmartians.com/chronicles/build-images-on-github-actions-with-docker-layer-caching
+      - name: Move cache (reduce cache size)
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -2,7 +2,7 @@ name: build-docker
 on:
   push:
     branches:
-      - master
+      # - master
   release:
     types:
       - created

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -85,7 +85,7 @@ jobs:
             BASE_RUNTIME_IMAGE=${{ matrix.base_runtime_image }}
           target: ${{ matrix.target }}
           push: true
-          tags: ${{ env.IMAGE_NAME }}:${{ (matrix.tag == 'latest' && '') || matrix.tag }}${{ (matrix.tag == 'latest' && '') || '-' }}${{ github.event.release.tag_name }}
+          tags: ${{ env.IMAGE_NAME }}:${{ github.event.release.tag_name }}${{ (matrix.tag == 'latest' && '') || '-' }}${{ (matrix.tag == 'latest' && '') || matrix.tag }}
           cache-from: type=local,src=/tmp/.buildx-cache-new
           cache-to: type=local,mode=max,dest=/tmp/.buildx-cache-new
 

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -56,12 +56,22 @@ jobs:
         uses: actions/cache@v2
         with:
           path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ matrix.base_runtime_image }}-${{ github.sha }}
+          key: ${{ runner.os }}-buildx-${{ matrix.tag || 'latest' }}-${{ github.sha }}
           restore-keys: |
-            ${{ runner.os }}-buildx-${{ matrix.base_runtime_image }}
+            ${{ runner.os }}-buildx-${{ matrix.tag || 'latest' }}
 
       - name: Build and Deploy Docker image
         uses: docker/build-push-action@v2
+        env:
+          IMAGE_TAG: ${{ env.IMAGE_NAME }}:${{ matrix.tag }}${{ (matrix.tag != '' && '-') || '' }}latest
+          VERSIONED_IMAGE_TAG: |
+            ${{ (
+              github.event.release.tag_name != '' && (
+                matrix.tag != '' && (
+                  format('{0}:{1}-{2}', env.IMAGE_NAME, matrix.tag, github.event.release.tag_name)
+                ) || format('{0}:{1}', env.IMAGE_NAME, github.event.release.tag_name)
+              )
+            ) || '' }}
         with:
           context: .
           builder: ${{ steps.buildx.outputs.name }}
@@ -70,23 +80,10 @@ jobs:
             BASE_RUNTIME_IMAGE=${{ matrix.base_runtime_image }}
           target: ${{ matrix.target }}
           push: true
-          tags: ${{ env.IMAGE_NAME }}:${{ matrix.tag }}${{ (matrix.tag != '' && '-') || '' }}latest
+          tags: |
+            ${{ env.IMAGE_TAG }}
+            ${{ env.VERSIONED_IMAGE_TAG }}
           cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,mode=max,dest=/tmp/.buildx-cache-new
-
-      - name: Build and Deploy versioned Docker image
-        if: success() && github.event.release.tag_name != ''
-        uses: docker/build-push-action@v2
-        with:
-          context: .
-          builder: ${{ steps.buildx.outputs.name }}
-          file: ./Dockerfile
-          build-args: |
-            BASE_RUNTIME_IMAGE=${{ matrix.base_runtime_image }}
-          target: ${{ matrix.target }}
-          push: true
-          tags: ${{ env.IMAGE_NAME }}:${{ matrix.tag }}${{ (matrix.tag != '' && '-') || '' }}${{ github.event.release.tag_name }}
-          cache-from: type=local,src=/tmp/.buildx-cache-new
           cache-to: type=local,mode=max,dest=/tmp/.buildx-cache-new
 
       - name: Move cache (reduce cache size)

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -70,7 +70,7 @@ jobs:
             BASE_RUNTIME_IMAGE=${{ matrix.base_runtime_image }}
           target: ${{ matrix.target }}
           push: true
-          tags: ${{ env.IMAGE_NAME }}:${{ matrix.tag }}${{ (matrix.tag == '' && '') || '-' }}latest
+          tags: ${{ env.IMAGE_NAME }}:${{ matrix.tag }}${{ (matrix.tag != '' && '-') || '' }}latest
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,mode=max,dest=/tmp/.buildx-cache-new
 
@@ -85,7 +85,7 @@ jobs:
             BASE_RUNTIME_IMAGE=${{ matrix.base_runtime_image }}
           target: ${{ matrix.target }}
           push: true
-          tags: ${{ env.IMAGE_NAME }}:${{ matrix.tag }}${{ (matrix.tag == '' && '') || '-' }}${{ github.event.release.tag_name }}
+          tags: ${{ env.IMAGE_NAME }}:${{ matrix.tag }}${{ (matrix.tag != '' && '-') || '' }}${{ github.event.release.tag_name }}
           cache-from: type=local,src=/tmp/.buildx-cache-new
           cache-to: type=local,mode=max,dest=/tmp/.buildx-cache-new
 

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -68,6 +68,12 @@ jobs:
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new
 
+      - name: Update Docker Hub description with README.md
+        uses: peter-evans/dockerhub-description@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       # https://evilmartians.com/chronicles/build-images-on-github-actions-with-docker-layer-caching
       - name: Move cache (reduce cache size)
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,6 +62,58 @@ RUN <<EOF
 EOF
 
 
+# Compile Python (version locked)
+FROM ubuntu:focal AS compile-python-env
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG PYTHON_VERSION=3.7.12
+ARG PYENV_ROOT=/tmp/.pyenv
+ARG PYBUILD_ROOT=/tmp/python-build
+
+RUN <<EOF
+    apt-get update
+    apt-get install -y \
+        build-essential \
+        libssl-dev \
+        zlib1g-dev \
+        libbz2-dev \
+        libreadline-dev \
+        libsqlite3-dev \
+        wget \
+        curl \
+        llvm \
+        libncurses5-dev \
+        libncursesw5-dev \
+        xz-utils \
+        tk-dev \
+        libffi-dev \
+        liblzma-dev \
+        python-openssl \
+        git
+    apt-get clean
+    rm -rf /var/lib/apt/lists/*
+EOF
+
+RUN <<EOF
+    git clone https://github.com/pyenv/pyenv.git "$PYENV_ROOT"
+    PREFIX="$PYBUILD_ROOT" "$PYENV_ROOT"/plugins/python-build/install.sh
+    "$PYBUILD_ROOT/bin/python-build" -v "$PYTHON_VERSION" /opt/python
+    rm -rf "$PYBUILD_ROOT" "$PYENV_ROOT"
+EOF
+
+# not working: /etc/profile read only on login shell
+# not working: /etc/environment is the same
+# not suitable: `ENV` is ignored by docker-compose
+# RUN <<EOF
+#     echo "export PATH=/opt/python/bin:\$PATH" > /etc/profile.d/python-path.sh
+#     echo "export LD_LIBRARY_PATH=/opt/python/lib:\$LD_LIBRARY_PATH" >> /etc/profile.d/python-path.sh
+#     echo "export C_INCLUDE_PATH=/opt/python/include:\$C_INCLUDE_PATH" >> /etc/profile.d/python-path.sh
+#
+#     rm -f /etc/ld.so.cache
+#     ldconfig
+# EOF
+
+
 # Runtime
 FROM ${BASE_RUNTIME_IMAGE} AS runtime-env
 ARG DEBIAN_FRONTEND=noninteractive
@@ -70,19 +122,23 @@ WORKDIR /opt/voicevox_engine
 
 # libsndfile1: soundfile shared object
 # ca-certificates: pyopenjtalk dictionary download
+# build-essential: pyopenjtalk local build
 RUN <<EOF
     apt-get update
     apt-get install -y \
-        python3 \
-        python3-pip \
         git \
         cmake \
         libsndfile1 \
-        ca-certificates
+        ca-certificates \
+        build-essential
     apt-get clean
     rm -rf /var/lib/apt/lists/*
 EOF
 
+COPY --from=compile-python-env /opt/python /opt/python
+
+# temporary override PATH for convenience during the image building
+ARG PATH=/opt/python/bin:$PATH
 ADD ./requirements.txt ./requirements-dev.txt /tmp/
 RUN <<EOF
     python3 -m pip install --upgrade pip setuptools wheel
@@ -120,8 +176,8 @@ RUN <<EOF
     ldconfig
 EOF
 
-CMD [ "python3", "./run.py", "--voicevox_dir", "/opt/voicevox_core/", "--voicelib_dir", "/opt/voicevox_core/", "--host", "0.0.0.0" ]
+CMD [ "/opt/python/bin/python3", "./run.py", "--voicevox_dir", "/opt/voicevox_core/", "--voicelib_dir", "/opt/voicevox_core/", "--host", "0.0.0.0" ]
 
 # enable use_gpu
 FROM runtime-env AS runtime-nvidia-env
-CMD [ "python3", "./run.py", "--use_gpu", "--voicevox_dir", "/opt/voicevox_core/", "--voicelib_dir", "/opt/voicevox_core/", "--host", "0.0.0.0" ]
+CMD [ "/opt/python/bin/python3", "./run.py", "--use_gpu", "--voicevox_dir", "/opt/voicevox_core/", "--voicelib_dir", "/opt/voicevox_core/", "--host", "0.0.0.0" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,8 +51,8 @@ EOF
 
 ADD ./requirements.txt ./requirements-dev.txt /tmp/
 RUN <<EOF
-    python -m pip install --upgrade pip setuptools wheel
-    pip install -r /tmp/requirements-dev.txt
+    python3 -m pip install --upgrade pip setuptools wheel
+    pip3 install -r /tmp/requirements-dev.txt
 EOF
 
 COPY --from=download-core-env /opt/voicevox_core /opt/voicevox_core
@@ -62,6 +62,8 @@ ADD ./voicevox_engine /opt/voicevox_engine/voicevox_engine
 ADD ./run.py ./check_tts.py ./VERSION.txt ./speakers.json ./LICENSE ./LGPL_LICENSE /opt/voicevox_engine/
 
 # Download openjtalk dictionary
-RUN python3 -c "import pyopenjtalk; pyopenjtalk._lazy_init()"
+RUN <<EOF
+    python3 -c "import pyopenjtalk; pyopenjtalk._lazy_init()"
+EOF
 
 CMD [ "python3", "./run.py", "--voicevox_dir", "/opt/voicevox_core", "--host", "0.0.0.0" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -193,7 +193,7 @@ RUN <<EOF
       rm -f /etc/ld.so.cache
       ldconfig
 
-      cat /opt/voicevox_core/README.txt
+      cat /opt/voicevox_core/README.txt > /dev/stderr
 
       exec "\$@"
   EOT

--- a/Dockerfile
+++ b/Dockerfile
@@ -139,10 +139,10 @@ COPY --from=compile-python-env /opt/python /opt/python
 
 # temporary override PATH for convenience during the image building
 ARG PATH=/opt/python/bin:$PATH
-ADD ./requirements.txt ./requirements-dev.txt /tmp/
+ADD ./requirements.txt /tmp/
 RUN <<EOF
     python3 -m pip install --upgrade pip setuptools wheel
-    pip3 install -r /tmp/requirements-dev.txt
+    pip3 install -r /tmp/requirements.txt
 EOF
 
 # Copy VOICEVOX Core shared object

--- a/Dockerfile
+++ b/Dockerfile
@@ -187,12 +187,18 @@ RUN <<EOF
     gosu user /opt/python/bin/python3 -c "import pyopenjtalk; pyopenjtalk._lazy_init()"
 EOF
 
-# Force update ldconfig cache
+# Update ldconfig on container start
 RUN <<EOF
-    rm -f /etc/ld.so.cache
-    ldconfig
+  cat <<EOT > /entrypoint.sh
+      rm -f /etc/ld.so.cache
+      ldconfig
+
+      exec "\$@"
+  EOT
+  chmod +x /entrypoint.sh
 EOF
 
+ENTRYPOINT [ "bash", "/entrypoint.sh"  ]
 CMD [ "gosu", "user", "/opt/python/bin/python3", "./run.py", "--voicevox_dir", "/opt/voicevox_core/", "--voicelib_dir", "/opt/voicevox_core/", "--host", "0.0.0.0" ]
 
 # Enable use_gpu

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ EOF
 
 RUN <<EOF
     echo "/opt/voicevox_core" > /etc/ld.so.conf.d/voicevox_core.conf
+    rm -f /etc/ld.so.cache
     ldconfig
 EOF
 
@@ -56,6 +57,7 @@ EOF
 
 RUN <<EOF
     echo "/opt/libtorch/lib" > /etc/ld.so.conf.d/libtorch.conf
+    rm -f /etc/ld.so.cache
     ldconfig
 EOF
 
@@ -94,9 +96,6 @@ COPY --from=download-core-env /opt/voicevox_core /opt/voicevox_core
 # Copy LibTorch
 COPY --from=download-libtorch-env /etc/ld.so.conf.d/libtorch.conf /etc/ld.so.conf.d/libtorch.conf
 COPY --from=download-libtorch-env /opt/libtorch /opt/libtorch
-RUN <<EOF
-    ldconfig
-EOF
 
 ARG VOICEVOX_CORE_EXAMPLE_VERSION=0.5.2
 RUN <<EOF
@@ -113,6 +112,12 @@ ADD ./run.py ./check_tts.py ./VERSION.txt ./speakers.json ./LICENSE ./LGPL_LICEN
 # Download openjtalk dictionary
 RUN <<EOF
     python3 -c "import pyopenjtalk; pyopenjtalk._lazy_init()"
+EOF
+
+# force update ldconfig cache
+RUN <<EOF
+    rm -f /etc/ld.so.cache
+    ldconfig
 EOF
 
 CMD [ "python3", "./run.py", "--voicevox_dir", "/opt/voicevox_core/", "--voicelib_dir", "/opt/voicevox_core/", "--host", "0.0.0.0" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@
 
 ARG BASE_RUNTIME_IMAGE=ubuntu:focal
 
+# Download VOICEVOX Core shared object
 FROM ubuntu:focal AS download-core-env
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -30,6 +31,36 @@ RUN <<EOF
 EOF
 
 
+# Download LibTorch
+FROM ubuntu:focal AS download-libtorch-env
+ARG DEBIAN_FRONTEND=noninteractive
+
+WORKDIR /work
+
+RUN <<EOF
+    apt-get update
+    apt-get install -y \
+        wget \
+        unzip
+    apt-get clean
+    rm -rf /var/lib/apt/lists/*
+EOF
+
+ARG LIBTORCH_URL=https://download.pytorch.org/libtorch/cu111/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcu111.zip
+RUN <<EOF
+    wget -nv --show-progress -c -O "./libtorch.zip" "${LIBTORCH_URL}"
+    unzip "./libtorch.zip"
+    mv ./libtorch /opt/libtorch
+    rm ./libtorch.zip
+EOF
+
+RUN <<EOF
+    echo "/opt/libtorch/lib" > /etc/ld.so.conf.d/libtorch.conf
+    ldconfig
+EOF
+
+
+# Runtime
 FROM ${BASE_RUNTIME_IMAGE} AS runtime-env
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -56,17 +87,20 @@ RUN <<EOF
     pip3 install -r /tmp/requirements-dev.txt
 EOF
 
+# Copy VOICEVOX Core shared object
 COPY --from=download-core-env /etc/ld.so.conf.d/voicevox_core.conf /etc/ld.so.conf.d/voicevox_core.conf
 COPY --from=download-core-env /opt/voicevox_core /opt/voicevox_core
+
+# Copy LibTorch
+COPY --from=download-libtorch-env /etc/ld.so.conf.d/libtorch.conf /etc/ld.so.conf.d/libtorch.conf
+COPY --from=download-libtorch-env /opt/libtorch /opt/libtorch
 RUN <<EOF
     ldconfig
 EOF
 
-# TODO: install libtorch
-
 ARG VOICEVOX_CORE_EXAMPLE_VERSION=0.5.2
 RUN <<EOF
-  git clone -b "${VOICEVOX_CORE_EXAMPLE_VERSION}" https://github.com/Hiroshiba/voicevox_core.git /opt/voicevox_core_example
+  git clone -b "${VOICEVOX_CORE_EXAMPLE_VERSION}" --depth 1 https://github.com/Hiroshiba/voicevox_core.git /opt/voicevox_core_example
   cd /opt/voicevox_core_example
   cp ./core.h ./example/python/
   cd example/python
@@ -81,4 +115,8 @@ RUN <<EOF
     python3 -c "import pyopenjtalk; pyopenjtalk._lazy_init()"
 EOF
 
-CMD [ "python3", "./run.py", "--voicevox_dir", "/opt/voicevox_core/", "--host", "0.0.0.0" ]
+CMD [ "python3", "./run.py", "--voicevox_dir", "/opt/voicevox_core/", "--voicelib_dir", "/opt/voicevox_core/", "--host", "0.0.0.0" ]
+
+# enable use_gpu
+FROM runtime-env AS runtime-nvidia-env
+CMD [ "python3", "./run.py", "--use_gpu", "--voicevox_dir", "/opt/voicevox_core/", "--voicelib_dir", "/opt/voicevox_core/", "--host", "0.0.0.0" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ EOF
 
 RUN <<EOF
     echo "/opt/voicevox_core" > /etc/ld.so.conf.d/voicevox_core.conf
+    ldconfig
 EOF
 
 
@@ -57,6 +58,9 @@ EOF
 
 COPY --from=download-core-env /opt/voicevox_core /opt/voicevox_core
 COPY --from=download-core-env /etc/ld.so.conf.d/voicevox_core.conf /etc/ld.so.conf.d/voicevox_core.conf
+RUN <<EOF
+    ldconfig
+EOF
 
 ADD ./voicevox_engine /opt/voicevox_engine/voicevox_engine
 ADD ./run.py ./check_tts.py ./VERSION.txt ./speakers.json ./LICENSE ./LGPL_LICENSE /opt/voicevox_engine/

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,10 +56,21 @@ RUN <<EOF
     pip3 install -r /tmp/requirements-dev.txt
 EOF
 
-COPY --from=download-core-env /opt/voicevox_core /opt/voicevox_core
 COPY --from=download-core-env /etc/ld.so.conf.d/voicevox_core.conf /etc/ld.so.conf.d/voicevox_core.conf
+COPY --from=download-core-env /opt/voicevox_core /opt/voicevox_core
 RUN <<EOF
     ldconfig
+EOF
+
+# TODO: install libtorch
+
+ARG VOICEVOX_CORE_EXAMPLE_VERSION=0.5.2
+RUN <<EOF
+  git clone -b "${VOICEVOX_CORE_EXAMPLE_VERSION}" https://github.com/Hiroshiba/voicevox_core.git /opt/voicevox_core_example
+  cd /opt/voicevox_core_example
+  cp ./core.h ./example/python/
+  cd example/python
+  LIBRARY_PATH="/opt/voicevox_core:$LIBRARY_PATH" pip3 install .
 EOF
 
 ADD ./voicevox_engine /opt/voicevox_engine/voicevox_engine
@@ -70,4 +81,4 @@ RUN <<EOF
     python3 -c "import pyopenjtalk; pyopenjtalk._lazy_init()"
 EOF
 
-CMD [ "python3", "./run.py", "--voicevox_dir", "/opt/voicevox_core", "--host", "0.0.0.0" ]
+CMD [ "python3", "./run.py", "--voicevox_dir", "/opt/voicevox_core/", "--host", "0.0.0.0" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -193,6 +193,8 @@ RUN <<EOF
       rm -f /etc/ld.so.cache
       ldconfig
 
+      cat /opt/voicevox_core/README.txt
+
       exec "\$@"
   EOT
   chmod +x /entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,70 @@
+# syntax=docker/dockerfile:1.3-labs
+
+ARG BASE_RUNTIME_IMAGE=ubuntu:focal
+
+FROM ubuntu:focal AS download-core-env
+ARG DEBIAN_FRONTEND=noninteractive
+
+WORKDIR /work
+
+RUN <<EOF
+    apt-get update
+    apt-get install -y \
+        wget \
+        unzip
+    apt-get clean
+    rm -rf /var/lib/apt/lists/*
+EOF
+
+ARG VOICEVOX_CORE_VERSION=0.5.2
+RUN <<EOF
+    wget -nv --show-progress -c -O "./core.zip" "https://github.com/Hiroshiba/voicevox_core/releases/download/${VOICEVOX_CORE_VERSION}/core.zip"
+    unzip "./core.zip"
+    mv ./core /opt/voicevox_core
+    rm ./core.zip
+EOF
+
+RUN <<EOF
+    mkdir -p /etc/ld.conf.so.d
+    echo "/opt/voicevox_core" > /etc/ld.conf.so.d/voicevox_core.conf
+EOF
+
+
+FROM ${BASE_RUNTIME_IMAGE} AS runtime-env
+ARG DEBIAN_FRONTEND=noninteractive
+
+WORKDIR /opt/voicevox_engine
+
+# libsndfile1: soundfile shared object
+# ca-certificates: pyopenjtalk dictionary download
+RUN <<EOF
+    apt-get update
+    apt-get install -y \
+        python3 \
+        python3-pip \
+        git \
+        cmake \
+        libsndfile1 \
+        ca-certificates
+    apt-get clean
+    rm -rf /var/lib/apt/lists/*
+EOF
+
+ADD ./requirements.txt ./requirements-dev.txt /tmp/
+RUN <<EOF
+    python -m pip install --upgrade pip setuptools wheel
+    pip install -r /tmp/requirements-dev.txt
+EOF
+
+COPY --from=download-core-env /opt/voicevox_core /opt/voicevox_core
+
+RUN mkdir -p /etc/ld.conf.so.d
+COPY --from=download-core-env /etc/ld.conf.so.d/voicevox_core.conf /etc/ld.conf.so.d/voicevox_core.conf
+
+ADD ./voicevox_engine /opt/voicevox_engine/voicevox_engine
+ADD ./run.py ./check_tts.py ./VERSION.txt ./speakers.json ./LICENSE ./LGPL_LICENSE /opt/voicevox_engine/
+
+# Download openjtalk dictionary
+RUN python3 -c "import pyopenjtalk; pyopenjtalk._lazy_init()"
+
+CMD [ "python3", "./run.py", "--voicevox_dir", "/opt/voicevox_core", "--host", "0.0.0.0" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,8 +25,7 @@ RUN <<EOF
 EOF
 
 RUN <<EOF
-    mkdir -p /etc/ld.conf.so.d
-    echo "/opt/voicevox_core" > /etc/ld.conf.so.d/voicevox_core.conf
+    echo "/opt/voicevox_core" > /etc/ld.so.conf.d/voicevox_core.conf
 EOF
 
 
@@ -57,9 +56,7 @@ RUN <<EOF
 EOF
 
 COPY --from=download-core-env /opt/voicevox_core /opt/voicevox_core
-
-RUN mkdir -p /etc/ld.conf.so.d
-COPY --from=download-core-env /etc/ld.conf.so.d/voicevox_core.conf /etc/ld.conf.so.d/voicevox_core.conf
+COPY --from=download-core-env /etc/ld.so.conf.d/voicevox_core.conf /etc/ld.so.conf.d/voicevox_core.conf
 
 ADD ./voicevox_engine /opt/voicevox_engine/voicevox_engine
 ADD ./run.py ./check_tts.py ./VERSION.txt ./speakers.json ./LICENSE ./LGPL_LICENSE /opt/voicevox_engine/

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,8 @@ CMD=
 build-linux-docker-nvidia:
 	docker buildx build . \
 		-t aoirint/voicevox_engine:nvidia-ubuntu20.04 \
+		--target runtime-nvidia-env \
+		--progress plain \
 		--build-arg BASE_RUNTIME_IMAGE=nvidia/cuda:11.4.1-cudnn8-runtime-ubuntu20.04
 
 run-linux-docker-nvidia:

--- a/Makefile
+++ b/Makefile
@@ -24,3 +24,14 @@ run-linux-docker-nvidia:
 		--gpus all \
 		-p '127.0.0.1:50021:50021' \
 		aoirint/voicevox_engine:nvidia-ubuntu20.04 $(CMD)
+
+build-linux-docker-compile-python-env:
+	docker buildx build . \
+		-t aoirint/voicevox_engine:compile-python-env \
+		--target compile-python-env \
+		--progress plain \
+		--build-arg BASE_RUNTIME_IMAGE=ubuntu:focal
+
+run-linux-docker-compile-python-env:
+	docker run --rm -it \
+		aoirint/voicevox_engine:compile-python-env $(CMD)

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,17 @@
 CMD=
 
+build-linux-docker-ubuntu:
+	docker buildx build . \
+		-t aoirint/voicevox_engine:cpu-ubuntu20.04 \
+		--target runtime-env \
+		--progress plain \
+		--build-arg BASE_RUNTIME_IMAGE=ubuntu:focal
+
+run-linux-docker-ubuntu:
+	docker run --rm -it \
+		-p '127.0.0.1:50021:50021' \
+		aoirint/voicevox_engine:cpu-ubuntu20.04 $(CMD)
+
 build-linux-docker-nvidia:
 	docker buildx build . \
 		-t aoirint/voicevox_engine:nvidia-ubuntu20.04 \

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,12 @@
 CMD=
 
-build-linux-docker:
-	docker buildx build . -t voicevox/voicevox_engine
+build-linux-docker-nvidia:
+	docker buildx build . \
+		-t aoirint/voicevox_engine:nvidia-ubuntu20.04 \
+		--build-arg BASE_RUNTIME_IMAGE=nvidia/cuda:11.4.1-cudnn8-runtime-ubuntu20.04
 
-run-linux-docker:
-	docker run --rm -it -p '127.0.0.1:50021:50021' voicevox/voicevox_engine $(CMD)
+run-linux-docker-nvidia:
+	docker run --rm -it \
+		--gpus all \
+		-p '127.0.0.1:50021:50021' \
+		aoirint/voicevox_engine:nvidia-ubuntu20.04 $(CMD)

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+CMD=
+
+build-linux-docker:
+	docker buildx build . -t voicevox/voicevox_engine
+
+run-linux-docker:
+	docker run --rm -it -p '127.0.0.1:50021:50021' voicevox/voicevox_engine $(CMD)

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 CMD=
 
+.PHONY: build-linux-docker-ubuntu
 build-linux-docker-ubuntu:
 	docker buildx build . \
 		-t aoirint/voicevox_engine:cpu-ubuntu20.04 \
@@ -7,11 +8,13 @@ build-linux-docker-ubuntu:
 		--progress plain \
 		--build-arg BASE_RUNTIME_IMAGE=ubuntu:focal
 
+.PHONY: run-linux-docker-ubuntu
 run-linux-docker-ubuntu:
 	docker run --rm -it \
 		-p '127.0.0.1:50021:50021' \
 		aoirint/voicevox_engine:cpu-ubuntu20.04 $(CMD)
 
+.PHONY: build-linux-docker-nvidia
 build-linux-docker-nvidia:
 	docker buildx build . \
 		-t aoirint/voicevox_engine:nvidia-ubuntu20.04 \
@@ -19,12 +22,14 @@ build-linux-docker-nvidia:
 		--progress plain \
 		--build-arg BASE_RUNTIME_IMAGE=nvidia/cuda:11.4.1-cudnn8-runtime-ubuntu20.04
 
+.PHONY: run-linux-docker-nvidia
 run-linux-docker-nvidia:
 	docker run --rm -it \
 		--gpus all \
 		-p '127.0.0.1:50021:50021' \
 		aoirint/voicevox_engine:nvidia-ubuntu20.04 $(CMD)
 
+.PHONY: build-linux-docker-compile-python-env
 build-linux-docker-compile-python-env:
 	docker buildx build . \
 		-t aoirint/voicevox_engine:compile-python-env \
@@ -32,6 +37,7 @@ build-linux-docker-compile-python-env:
 		--progress plain \
 		--build-arg BASE_RUNTIME_IMAGE=ubuntu:focal
 
+.PHONY: run-linux-docker-compile-python-env
 run-linux-docker-compile-python-env:
 	docker run --rm -it \
 		aoirint/voicevox_engine:compile-python-env $(CMD)

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ CMD=
 .PHONY: build-linux-docker-ubuntu
 build-linux-docker-ubuntu:
 	docker buildx build . \
-		-t aoirint/voicevox_engine:cpu-ubuntu20.04 \
+		-t aoirint/voicevox_engine:cpu-ubuntu20.04-latest \
 		--target runtime-env \
 		--progress plain \
 		--build-arg BASE_RUNTIME_IMAGE=ubuntu:focal
@@ -12,12 +12,12 @@ build-linux-docker-ubuntu:
 run-linux-docker-ubuntu:
 	docker run --rm -it \
 		-p '127.0.0.1:50021:50021' \
-		aoirint/voicevox_engine:cpu-ubuntu20.04 $(CMD)
+		aoirint/voicevox_engine:cpu-ubuntu20.04-latest $(CMD)
 
 .PHONY: build-linux-docker-nvidia
 build-linux-docker-nvidia:
 	docker buildx build . \
-		-t aoirint/voicevox_engine:nvidia-ubuntu20.04 \
+		-t aoirint/voicevox_engine:nvidia-ubuntu20.04-latest \
 		--target runtime-nvidia-env \
 		--progress plain \
 		--build-arg BASE_RUNTIME_IMAGE=nvidia/cuda:11.4.1-cudnn8-runtime-ubuntu20.04
@@ -27,7 +27,7 @@ run-linux-docker-nvidia:
 	docker run --rm -it \
 		--gpus all \
 		-p '127.0.0.1:50021:50021' \
-		aoirint/voicevox_engine:nvidia-ubuntu20.04 $(CMD)
+		aoirint/voicevox_engine:nvidia-ubuntu20.04-latest $(CMD)
 
 .PHONY: build-linux-docker-compile-python-env
 build-linux-docker-compile-python-env:

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ curl -s \
     > audio.wav
 ```
 
-## Dockerイメージ
+## Docker イメージ
 
 ### CPU
 ```bash

--- a/README.md
+++ b/README.md
@@ -109,6 +109,14 @@ python -m nuitka \
     run.py
 ```
 
+## GitHub Actions
+
+### Secrets
+|name|description|
+|:--|:--|
+|DOCKERHUB_USERNAME|Docker Hub ユーザ名|
+|DOCKERHUB_TOKEN|[Docker Hub アクセストークン](https://hub.docker.com/settings/security)|
+
 ## ライセンス
 
 LGPL v3 と、ソースコードの公開が不要な別ライセンスのデュアルライセンスです。

--- a/README.md
+++ b/README.md
@@ -30,14 +30,14 @@ curl -s \
 
 ### CPU
 ```bash
-docker pull aoirint/voicevox_engine:cpu-ubuntu20.04
-docker run --rm -it -p '127.0.0.1:50021:50021' aoirint/voicevox_engine:cpu-ubuntu20.04
+docker pull aoirint/voicevox_engine:cpu-ubuntu20.04-latest
+docker run --rm -it -p '127.0.0.1:50021:50021' aoirint/voicevox_engine:cpu-ubuntu20.04-latest
 ```
 
 ### GPU
 ```bash
-docker pull aoirint/voicevox_engine:nvidia-ubuntu20.04
-docker run --rm --gpus all -p '127.0.0.1:50021:50021' aoirint/voicevox_engine:nvidia-ubuntu20.04
+docker pull aoirint/voicevox_engine:nvidia-ubuntu20.04-latest
+docker run --rm --gpus all -p '127.0.0.1:50021:50021' aoirint/voicevox_engine:nvidia-ubuntu20.04-latest
 ```
 
 ## 貢献者の方へ

--- a/README.md
+++ b/README.md
@@ -26,6 +26,20 @@ curl -s \
     > audio.wav
 ```
 
+## Dockerイメージ
+
+### CPU
+```bash
+docker pull aoirint/voicevox_engine:cpu-ubuntu20.04
+docker run --rm -it -p '127.0.0.1:50021:50021' aoirint/voicevox_engine:cpu-ubuntu20.04
+```
+
+### GPU
+```bash
+docker pull aoirint/voicevox_engine:nvidia-ubuntu20.04
+docker run --rm --gpus all -p '127.0.0.1:50021:50021' aoirint/voicevox_engine:nvidia-ubuntu20.04
+```
+
 ## 貢献者の方へ
 
 Issue を解決するプルリクエストを作成される際は、別の方と同じ Issue に取り組むことを避けるため、


### PR DESCRIPTION
ref: #84

## 実装
- [x] CPU（ベースイメージ：ubuntu）で動作するイメージ
- [x] GPU（ベースイメージ：nvidia/cuda）で動作するイメージ
- [x] DockerイメージをGitHub ActionsでビルドしてDocker Hubにデプロイ
- [x] GitHub Releases作成時にバージョン付きタグでDocker Hubにデプロイ
- [x] Pythonバージョンの固定、build-arg化（Python 3.7.x）
- [x] 一般ユーザで実行

## 確認
- run.pyをnuitkaでビルドするか、しないか
    -  現在は、イメージビルド時間短縮のため、ビルドしない実装になっています
- Dockerイメージのデプロイ先
    - Docker Hub
- イメージ名`aoirint/voicevox_engine`の変更（変更案：`voicevox/voicevox_engine`または`hiroshiba/voicevox_engine`）
    - 暫定的に自分のアカウント以下のものになっているため、用意・変更をお願いしたいです
- Dockerイメージのビルド・デプロイタイミング
    - masterブランチにpushされたとき（latest）
    - GitHub Releasesが作成されたとき（バージョン付きタグ）
- buildkitでビルドしているのはキャッシュのためです
- coreパッケージ作成のため、voicevox_coreリポジトリのexample/python/setup.pyを利用していますが、example側を改変しにくくなるのでよくないかもしれません

### Dockerイメージのデプロイ先の候補
- Docker Hub
- GitHub Container Registry (ghcr.io)
- ほか

現在、Docker HubのみWorkflowのStepを用意しています。

- サンプル: https://hub.docker.com/r/aoirint/voicevox_engine

Docker Hubは、Freeアカウント（Docker Personal）ではアクセストークンを1アカウントにつき1つしか発行できないため、
既存の個人アカウントを使うとスコープの分離ができない懸念があります。

Docker Hubのアクセストークンにはイメージの説明（Overviewに表示される文章）を更新する権限がないため、
README.mdと同期させたい場合は、手動で更新が必要です。

## メンテナ側で必要な設定
### GitHub Secretsの設定

- DOCKERHUB_USERNAME
- DOCKERHUB_TOKEN

https://hub.docker.com/settings/security

上記URLで生成したアクセストークンを`DOCKERHUB_TOKEN`として、GitHub Secretsに登録する必要があります。
また、Docker Hubのアカウント名を`DOCKERHUB_USERNAME`として、GitHub Secretsに登録する必要があります。

