### PR TITLE
[WIP] core の mock に metas を追加

### DIFF
--- a/run.py
+++ b/run.py
@@ -312,9 +312,16 @@ def generate_app(engine: SynthesisEngine) -> FastAPI:
 
     @app.get("/speakers", response_model=List[Speaker], tags=["その他"])
     def speakers():
-        # TODO 音声ライブラリのAPIが出来たら差し替える
+        # TODO ここで import するのは避けたい
+        try:
+            import core
+        except ImportError:
+            import traceback
+
+            from voicevox_engine.dev import core
+
         return Response(
-            content=(root_dir / "speakers.json").read_text("utf-8"),
+            content=core.metas(),
             media_type="application/json",
         )
 

--- a/voicevox_engine/dev/core/__init__.py
+++ b/voicevox_engine/dev/core/__init__.py
@@ -1,3 +1,3 @@
-from .mock import decode_forward, initialize, yukarin_s_forward, yukarin_sa_forward
+from .mock import decode_forward, initialize, yukarin_s_forward, yukarin_sa_forward, metas
 
-__all__ = ["decode_forward", "initialize", "yukarin_s_forward", "yukarin_sa_forward"]
+__all__ = ["decode_forward", "initialize", "yukarin_s_forward", "yukarin_sa_forward", "metas"]

--- a/voicevox_engine/dev/core/mock.py
+++ b/voicevox_engine/dev/core/mock.py
@@ -68,3 +68,10 @@ def decode_forward(length: int, **kwargs: Dict[str, Any]) -> np.ndarray:
         filter="kaiser_fast",
     )
     return wave
+
+def metas() -> str:
+    logger = getLogger("uvicorn")  # FastAPI / Uvicorn 内からの利用のため
+    logger.info(
+        "Sorry, metas() is a mock. Return values are incorrect.",
+    )
+    return "[{\"name\": \"dummy1\", \"speaker_id\": 0},{\"name\": \"dummy2\", \"speaker_id\": 1}]"


### PR DESCRIPTION
`core.metas()` を mock に追加しましたが、`run.py` 側で使う際に、`import` するのは避けたいので、設計等考えたいです。
ご意見お待ちしております。