### PR TITLE
/multi_synthesisを追加

### DIFF
--- a/run.py
+++ b/run.py
@@ -344,7 +344,7 @@ def generate_app(engine: SynthesisEngine) -> FastAPI:
                 file=f, data=np.concatenate(waves), samplerate=samplingrate, format="WAV"
             )
 
-            return FileResponse(f.name, media_type="audio/wav")
+        return FileResponse(f.name, media_type="audio/wav")
 
     @app.get("/version", tags=["その他"])
     def version() -> str:

--- a/voicevox_engine/dev/synthesis_engine/mock.py
+++ b/voicevox_engine/dev/synthesis_engine/mock.py
@@ -19,6 +19,7 @@ class SynthesisEngine:
         __init__ [Mock]
         """
         super().__init__()
+        self.default_sampling_rate = 24000
 
     def replace_phoneme_length(
         self, accent_phrases: List[AccentPhrase], speaker_id: int

--- a/voicevox_engine/synthesis_engine.py
+++ b/voicevox_engine/synthesis_engine.py
@@ -2,6 +2,7 @@ from itertools import chain
 from typing import List, Optional
 
 import numpy
+import resampy
 
 from voicevox_engine.acoustic_feature_extractor import (
     BasePhoneme,
@@ -96,6 +97,7 @@ class SynthesisEngine:
         self.decode_forwarder = decode_forwarder
         self.yukarin_s_phoneme_class = OjtPhoneme
         self.yukarin_soso_phoneme_class = OjtPhoneme
+        self.default_sampling_rate = 24000
 
     def replace_phoneme_length(
         self, accent_phrases: List[AccentPhrase], speaker_id: int
@@ -342,5 +344,17 @@ class SynthesisEngine:
         # volume
         if query.volumeScale != 1:
             wave *= query.volumeScale
+
+        if query.outputSamplingRate != self.default_sampling_rate:
+            wave = resampy.resample(
+                wave,
+                self.default_sampling_rate,
+                query.outputSamplingRate,
+                filter="kaiser_fast",
+            )
+
+        # ステレオ変換
+        if query.outputStereo:
+            wave = numpy.array([wave, wave]).T
 
         return wave


### PR DESCRIPTION
## 内容
複数のクエリをまとめて投げると一つにまとまったwavを返す`/multi_synthesis`を追加します
`/synthesis`と似た処理をするため、`synthesis()`内にあった重複する処理を`_synthesis()`に切り出しています

`/synthesis`、`/multi_synthesis`（2、3個のクエリ）でテストしてきちんと出力されたのを確認済です