### PR TITLE
Linux用実行バイナリの自動ビルドを追加 (#95)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,7 +96,16 @@ jobs:
             -v "$(readlink -f "build"):/opt/voicevox_engine_build" \
             "${{ env.IMAGE_TAG }}"
 
+      # FIXME: versioned name may be useful; but
+      # actions/download-artifact and dawidd6/download-artifact do not support
+      # wildcard / forward-matching yet.
+      # Currently, It is good to use static artifact name for future binary test workflow.
+      # https://github.com/actions/toolkit/blob/ea81280a4d48fb0308d40f8f12ae00d117f8acb9/packages/artifact/src/internal/artifact-client.ts#L147
+      # https://github.com/dawidd6/action-download-artifact/blob/af92a8455a59214b7b932932f2662fdefbd78126/main.js#L113
       - uses: actions/upload-artifact@v2
+        # env:
+        #   VERSIONED_ARTIFACT_NAME: |
+        #     ${{ format('{0}-{1}', matrix.artifact_name, (github.event.release.tag_name != '' && github.event.release.tag_name) || github.sha) }}
         with:
           name: ${{ matrix.artifact_name }}
           path: build/run.dist/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,6 +38,8 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      # NOTE: `load: true` may silently fail when the GitHub Actions disk (14GB) is full.
+      # https://docs.github.com/ja/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
       - name: Create binary build environment with Docker
         uses: docker/build-push-action@v2
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,8 @@
 name: build
 on:
   push:
-    # branches:
-    #   - master
+    branches:
+      - master
   release:
     types:
       - created

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,83 @@
+name: build
+on:
+  push:
+    # branches:
+    #   - master
+  release:
+    types:
+      - created
+
+env:
+  IMAGE_NAME: ${{ secrets.DOCKERHUB_USERNAME }}/voicevox_engine
+
+jobs:
+  # Build Linux binary (push only buildcache image)
+  build-linux:
+    strategy:
+      matrix:
+        include:
+        - os: ubuntu-latest
+          tag: build-env-cpu-ubuntu20.04
+          runtime_tag: cpu-ubuntu20.04 # for cache use
+          target: build-env
+          base_runtime_image: ubuntu:focal
+          nuitka_cache_path: cache/Nuitka
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Create binary build environment with Docker
+        uses: docker/build-push-action@v2
+        env:
+          IMAGE_TAG: ${{ env.IMAGE_NAME }}:${{ matrix.tag }}${{ (matrix.tag != '' && '-') || '' }}latest
+          RUNTIME_IMAGE_TAG: ${{ env.IMAGE_NAME }}:${{ matrix.runtime_tag }}${{ (matrix.runtime_tag != '' && '-') || '' }}latest
+        with:
+          context: .
+          builder: ${{ steps.buildx.outputs.name }}
+          file: ./Dockerfile
+          build-args: |
+            BASE_RUNTIME_IMAGE=${{ matrix.base_runtime_image }}
+          target: ${{ matrix.target }}
+          load: true
+          tags: |
+            ${{ env.IMAGE_TAG }}
+          cache-from: |
+            type=registry,ref=${{ env.IMAGE_TAG }}-buildcache
+            type=registry,ref=${{ env.RUNTIME_IMAGE_TAG }}-buildcache
+          cache-to: type=registry,ref=${{ env.IMAGE_TAG }}-buildcache,mode=max
+
+      # Build run.py with Nuitka in Docker
+      - name: Cache Nuitka (ccache, module-cache)
+        uses: actions/cache@v2
+        id: nuitka-cache
+        with:
+          path: ${{ matrix.nuitka_cache_path }}
+          key: ${{ runner.os }}-nuitka-${{ matrix.target }}-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-nuitka-${{ matrix.target }}-
+
+      - name: Build run.py with Nuitka in Docker
+        env:
+          IMAGE_TAG: ${{ env.IMAGE_NAME }}:${{ matrix.tag }}${{ (matrix.tag != '' && '-') || '' }}latest
+        run: |
+          docker run --rm \
+            -v "$(readlink -f "${{ matrix.nuitka_cache_path }}"):/home/user/.cache/Nuitka" \
+            -v "$(readlink -f "build"):/opt/voicevox_engine_build" \
+            "${{ env.IMAGE_TAG }}"
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: run.dist
+          path: build/run.dist/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
           base_runtime_image: ubuntu:focal
           inference_device: cpu
           libtorch_url: https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcpu.zip
-          artifact_name: cpu
+          artifact_name: linux-cpu
           nuitka_cache_path: nuitka_cache
         - os: ubuntu-latest
           tag: build-nvidia-ubuntu20.04
@@ -34,7 +34,7 @@ jobs:
           base_runtime_image: nvidia/cuda:11.4.1-cudnn8-runtime-ubuntu20.04
           inference_device: nvidia
           libtorch_url: https://download.pytorch.org/libtorch/cu111/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcu111.zip
-          artifact_name: nvidia
+          artifact_name: linux-nvidia
           nuitka_cache_path: nuitka_cache
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
           runtime_tag: cpu-ubuntu20.04 # for cache use
           target: build-env
           base_runtime_image: ubuntu:focal
-          nuitka_cache_path: cache/Nuitka
+          nuitka_cache_path: nuitka_cache
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,5 +96,5 @@ jobs:
 
       - uses: actions/upload-artifact@v2
         with:
-          name: dist-${{ matrix.tag }}
+          name: ${{ matrix.tag }}-${{ github.sha }}
           path: build/run.dist/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,6 +95,9 @@ jobs:
             "${{ env.IMAGE_TAG }}"
 
       - uses: actions/upload-artifact@v2
+        env:
+          VERSIONED_ARTIFACT_NAME: |
+            format('{0}-{1}', matrix.tag, (github.event.release.tag_name != '' && github.event.release.tag_name) || github.sha)
         with:
-          name: ${{ matrix.tag }}-${{ github.sha }}
+          name: ${{ env.VERSIONED_ARTIFACT_NAME }}
           path: build/run.dist/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,10 @@ jobs:
           tag: build-env-cpu-ubuntu20.04
           runtime_tag: cpu-ubuntu20.04 # for cache use
           target: build-env
+          base_image: ubuntu:focal
           base_runtime_image: ubuntu:focal
+          inference_device: cpu
+          libtorch_url: https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcpu.zip
           nuitka_cache_path: nuitka_cache
 
     runs-on: ${{ matrix.os }}
@@ -50,7 +53,10 @@ jobs:
           builder: ${{ steps.buildx.outputs.name }}
           file: ./Dockerfile
           build-args: |
+            BASE_IMAGE=${{ matrix.base_image }}
             BASE_RUNTIME_IMAGE=${{ matrix.base_runtime_image }}
+            INFERENCE_DEVICE=${{ matrix.inference_device }}
+            LIBTORCH_URL=${{ matrix.libtorch_url }}
           target: ${{ matrix.target }}
           load: true
           tags: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,7 @@ jobs:
           base_runtime_image: ubuntu:focal
           inference_device: cpu
           libtorch_url: https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcpu.zip
+          artifact_name: cpu
           nuitka_cache_path: nuitka_cache
         - os: ubuntu-latest
           tag: build-nvidia-ubuntu20.04
@@ -33,6 +34,7 @@ jobs:
           base_runtime_image: nvidia/cuda:11.4.1-cudnn8-runtime-ubuntu20.04
           inference_device: nvidia
           libtorch_url: https://download.pytorch.org/libtorch/cu111/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcu111.zip
+          artifact_name: nvidia
           nuitka_cache_path: nuitka_cache
 
     runs-on: ${{ matrix.os }}
@@ -95,9 +97,6 @@ jobs:
             "${{ env.IMAGE_TAG }}"
 
       - uses: actions/upload-artifact@v2
-        env:
-          VERSIONED_ARTIFACT_NAME: |
-            ${{ format('{0}-{1}', matrix.tag, (github.event.release.tag_name != '' && github.event.release.tag_name) || github.sha) }}
         with:
-          name: ${{ env.VERSIONED_ARTIFACT_NAME }}
+          name: ${{ matrix.artifact_name }}
           path: build/run.dist/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,13 +17,22 @@ jobs:
       matrix:
         include:
         - os: ubuntu-latest
-          tag: build-env-cpu-ubuntu20.04
+          tag: build-cpu-ubuntu20.04
           runtime_tag: cpu-ubuntu20.04 # for cache use
           target: build-env
           base_image: ubuntu:focal
           base_runtime_image: ubuntu:focal
           inference_device: cpu
           libtorch_url: https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcpu.zip
+          nuitka_cache_path: nuitka_cache
+        - os: ubuntu-latest
+          tag: build-nvidia-ubuntu20.04
+          runtime_tag: nvidia-ubuntu20.04 # for cache use
+          target: build-env
+          base_image: ubuntu:focal
+          base_runtime_image: nvidia/cuda:11.4.1-cudnn8-runtime-ubuntu20.04
+          inference_device: nvidia
+          libtorch_url: https://download.pytorch.org/libtorch/cu111/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcu111.zip
           nuitka_cache_path: nuitka_cache
 
     runs-on: ${{ matrix.os }}
@@ -87,5 +96,5 @@ jobs:
 
       - uses: actions/upload-artifact@v2
         with:
-          name: run.dist
+          name: dist-${{ matrix.tag }}
           path: build/run.dist/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,7 +97,7 @@ jobs:
       - uses: actions/upload-artifact@v2
         env:
           VERSIONED_ARTIFACT_NAME: |
-            format('{0}-{1}', matrix.tag, (github.event.release.tag_name != '' && github.event.release.tag_name) || github.sha)
+            ${{ format('{0}-{1}', matrix.tag, (github.event.release.tag_name != '' && github.event.release.tag_name) || github.sha) }}
         with:
           name: ${{ env.VERSIONED_ARTIFACT_NAME }}
           path: build/run.dist/

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ __pycache__/
 venv/
 # JetBrains IDE project settings folder
 .idea/
+
+/build
+/cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -289,6 +289,7 @@ RUN <<EOF
                 --include-package-data=pyopenjtalk \
                 --include-package-data=resampy \
                 --include-data-file=/opt/voicevox_engine/VERSION.txt=./ \
+                --include-data-file=/opt/libtorch/lib/*.so=./ \
                 --include-data-file=/opt/libtorch/lib/*.so.*=./ \
                 --include-data-file=/opt/voicevox_core/*.so=./ \
                 --include-data-file=/opt/voicevox_core/*.bin=./ \

--- a/Dockerfile
+++ b/Dockerfile
@@ -289,7 +289,7 @@ RUN <<EOF
                 --include-package-data=pyopenjtalk \
                 --include-package-data=resampy \
                 --include-data-file=/opt/voicevox_engine/VERSION.txt=./ \
-                --include-data-file=/opt/libtorch/lib/*.so=./ \
+                --include-data-file=/opt/libtorch/lib/*.so.*=./ \
                 --include-data-file=/opt/voicevox_core/*.so=./ \
                 --include-data-file=/opt/voicevox_core/*.bin=./ \
                 --include-data-file=/opt/voicevox_core/metas.json=./ \

--- a/Dockerfile
+++ b/Dockerfile
@@ -289,7 +289,6 @@ RUN <<EOF
                 --include-package-data=pyopenjtalk \
                 --include-package-data=resampy \
                 --include-data-file=/opt/voicevox_engine/VERSION.txt=./ \
-                --include-data-file=/opt/voicevox_engine/speakers.json=./ \
                 --include-data-file=/opt/libtorch/lib/*.so=./ \
                 --include-data-file=/opt/voicevox_core/*.so=./ \
                 --include-data-file=/opt/voicevox_core/*.bin=./ \

--- a/Dockerfile
+++ b/Dockerfile
@@ -296,6 +296,7 @@ RUN <<EOF
                 --no-prefer-source-code \
                 /opt/voicevox_engine/run.py
 
+        # replace libcore.so link for libtorch to relative path
         cat <<EOT | xargs -I '%' patchelf --replace-needed "%" "./%" /opt/voicevox_engine_build/run.dist/libcore.so
             libc10.so
             libtorch_cuda.so
@@ -304,6 +305,8 @@ RUN <<EOF
             libtorch_cuda_cu.so
             libtorch.so
 EOT
+
+        chmod +x /opt/voicevox_engine_build/run.dist/run
 EOD
     chmod +x /build.sh
 EOF

--- a/Dockerfile
+++ b/Dockerfile
@@ -206,3 +206,66 @@ CMD [ "gosu", "user", "/opt/python/bin/python3", "./run.py", "--voicevox_dir", "
 # Enable use_gpu
 FROM runtime-env AS runtime-nvidia-env
 CMD [ "gosu", "user", "/opt/python/bin/python3", "./run.py", "--use_gpu", "--voicevox_dir", "/opt/voicevox_core/", "--voicelib_dir", "/opt/voicevox_core/", "--host", "0.0.0.0" ]
+
+# Binary build environment (common to CPU, GPU)
+FROM runtime-env AS build-env
+
+# Install ccache for Nuitka cache
+# chrpath: required for nuitka build; 'RPATH' seetings in used shared
+RUN <<EOF
+    apt-get update
+    apt-get install -y \
+        ccache \
+        chrpath
+    apt-get clean
+    rm -rf /var/lib/apt/lists/*
+EOF
+
+# Install Python build dependencies
+ADD ./requirements-dev.txt /tmp/
+RUN <<EOF
+    gosu user /opt/python/bin/pip3 install -r /tmp/requirements-dev.txt
+EOF
+
+# Create build script
+RUN <<EOF
+    set -eux
+
+    cat <<EOT > /build.sh
+        #!/bin/bash
+        set -eux
+
+        # chown general user c.z. mounted directory may be owned by root
+        mkdir -p /opt/voicevox_engine_build
+        chown -R user:user /opt/voicevox_engine_build
+
+        mkdir -p /home/user/.cache/Nuitka
+        chown -R user:user /home/user/.cache/Nuitka
+
+        cd /opt/voicevox_engine_build
+
+        LIBRARY_PATH="/opt/voicevox_core:\${LIBRARY_PATH:-}" \
+            gosu user /opt/python/bin/python3 -m nuitka \
+                --output-dir=/opt/voicevox_engine_build \
+                --standalone \
+                --plugin-enable=numpy \
+                --follow-import-to=numpy \
+                --follow-import-to=aiofiles \
+                --include-package=uvicorn \
+                --include-package-data=pyopenjtalk \
+                --include-package-data=resampy \
+                --include-data-file=/opt/voicevox_engine/VERSION.txt=./ \
+                --include-data-file=/opt/voicevox_engine/speakers.json=./ \
+                --include-data-file=/opt/libtorch/lib/*.so=./ \
+                --include-data-file=/opt/voicevox_core/*.so=./ \
+                --include-data-file=/opt/voicevox_core/*.bin=./ \
+                --include-data-file=/opt/voicevox_core/metas.json=./ \
+                --include-data-file=/home/user/.local/lib/python*/site-packages/llvmlite/binding/*.so=./ \
+                --follow-imports \
+                --no-prefer-source-code \
+                /opt/voicevox_engine/run.py
+EOT
+    chmod +x /build.sh
+EOF
+
+CMD [ "bash", "/build.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -265,7 +265,7 @@ EOF
 RUN <<EOF
     set -eux
 
-    cat <<EOT > /build.sh
+    cat <<EOD > /build.sh
         #!/bin/bash
         set -eux
 
@@ -298,7 +298,16 @@ RUN <<EOF
                 --follow-imports \
                 --no-prefer-source-code \
                 /opt/voicevox_engine/run.py
+
+        cat <<EOT | xargs -I '%' patchelf --replace-needed "%" "./%" /opt/voicevox_engine_build/libcore.so
+            libc10.so
+            libtorch_cuda.so
+            libtorch_cuda_cpp.so
+            libtorch_cpu.so
+            libtorch_cuda_cu.so
+            libtorch.so
 EOT
+EOD
     chmod +x /build.sh
 EOF
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -211,7 +211,7 @@ CMD [ "gosu", "user", "/opt/python/bin/python3", "./run.py", "--use_gpu", "--voi
 FROM runtime-env AS build-env
 
 # Install ccache for Nuitka cache
-# chrpath: required for nuitka build; 'RPATH' seetings in used shared
+# chrpath: required for nuitka build; 'RPATH' settings in used shared
 RUN <<EOF
     apt-get update
     apt-get install -y \

--- a/Dockerfile
+++ b/Dockerfile
@@ -250,7 +250,8 @@ RUN <<EOF
     apt-get update
     apt-get install -y \
         ccache \
-        chrpath
+        chrpath \
+        patchelf
     apt-get clean
     rm -rf /var/lib/apt/lists/*
 EOF

--- a/Dockerfile
+++ b/Dockerfile
@@ -218,7 +218,7 @@ RUN <<EOF
     gosu user pip3 install -r /tmp/requirements.txt
 
     # Install voicevox_core
-    cd /opt/voicevox_core_example/example/python 
+    cd /opt/voicevox_core_example/example/python
     gosu user pip3 install .
 
     # FIXME: remove first execution delay
@@ -296,7 +296,7 @@ RUN <<EOF
                 --no-prefer-source-code \
                 /opt/voicevox_engine/run.py
 
-        cat <<EOT | xargs -I '%' patchelf --replace-needed "%" "./%" /opt/voicevox_engine_build/libcore.so
+        cat <<EOT | xargs -I '%' patchelf --replace-needed "%" "./%" /opt/voicevox_engine_build/run.dist/libcore.so
             libc10.so
             libtorch_cuda.so
             libtorch_cuda_cpp.so

--- a/Makefile
+++ b/Makefile
@@ -41,8 +41,7 @@ build-linux-docker-compile-python-env:
 		-t hiroshiba/voicevox_engine:compile-python-env \
 		--target compile-python-env \
 		--progress plain \
-		--build-arg BASE_IMAGE=ubuntu:focal \
-		--build-arg BASE_RUNTIME_IMAGE=ubuntu:focal
+		--build-arg BASE_IMAGE=ubuntu:focal
 
 .PHONY: run-linux-docker-compile-python-env
 run-linux-docker-compile-python-env:

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ build-linux-docker-ubuntu:
 		-t hiroshiba/voicevox_engine:cpu-ubuntu20.04-latest \
 		--target runtime-env \
 		--progress plain \
+		--build-arg BASE_IMAGE=ubuntu:focal \
 		--build-arg BASE_RUNTIME_IMAGE=ubuntu:focal \
 		--build-arg LIBTORCH_URL=https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcpu.zip \
 		--build-arg INFERENCE_DEVICE=cpu
@@ -22,6 +23,7 @@ build-linux-docker-nvidia:
 		-t hiroshiba/voicevox_engine:nvidia-ubuntu20.04-latest \
 		--target runtime-nvidia-env \
 		--progress plain \
+		--build-arg BASE_IMAGE=ubuntu:focal \
 		--build-arg BASE_RUNTIME_IMAGE=nvidia/cuda:11.4.1-cudnn8-runtime-ubuntu20.04 \
 		--build-arg LIBTORCH_URL=https://download.pytorch.org/libtorch/cu111/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcu111.zip \
 		--build-arg INFERENCE_DEVICE=nvidia
@@ -39,6 +41,7 @@ build-linux-docker-compile-python-env:
 		-t hiroshiba/voicevox_engine:compile-python-env \
 		--target compile-python-env \
 		--progress plain \
+		--build-arg BASE_IMAGE=ubuntu:focal \
 		--build-arg BASE_RUNTIME_IMAGE=ubuntu:focal
 
 .PHONY: run-linux-docker-compile-python-env
@@ -53,6 +56,7 @@ build-linux-docker-build-env:
 		-t hiroshiba/voicevox_engine:build-env-cpu-ubuntu20.04-latest \
 		--target build-env \
 		--progress plain \
+		--build-arg BASE_IMAGE=ubuntu:focal \
 		--build-arg BASE_RUNTIME_IMAGE=ubuntu:focal
 
 .PHONY: run-linux-docker-build-env

--- a/Makefile
+++ b/Makefile
@@ -80,8 +80,8 @@ build-linux-docker-build-nvidia:
 		--build-arg LIBTORCH_URL=https://download.pytorch.org/libtorch/cu111/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcu111.zip \
 		--build-arg INFERENCE_DEVICE=nvidia
 
-.PHONY: run-linux-docker-build-env
-run-linux-docker-build-env:
+.PHONY: run-linux-docker-build-nvidia
+run-linux-docker-build-nvidia:
 	docker run --rm -it \
 		-v "$(shell pwd)/cache/Nuitka:/home/user/.cache/Nuitka" \
 		-v "$(shell pwd)/build:/opt/voicevox_engine_build" \

--- a/Makefile
+++ b/Makefile
@@ -50,18 +50,39 @@ run-linux-docker-compile-python-env:
 		hiroshiba/voicevox_engine:compile-python-env $(CMD)
 
 # Build linux binary in Docker
-.PHONY: build-linux-docker-build-env
-build-linux-docker-build-env:
+.PHONY: build-linux-docker-build
+build-linux-docker-build:
 	docker buildx build . \
-		-t hiroshiba/voicevox_engine:build-env-cpu-ubuntu20.04-latest \
+		-t hiroshiba/voicevox_engine:build-cpu-ubuntu20.04-latest \
 		--target build-env \
 		--progress plain \
 		--build-arg BASE_IMAGE=ubuntu:focal \
-		--build-arg BASE_RUNTIME_IMAGE=ubuntu:focal
+		--build-arg BASE_RUNTIME_IMAGE=ubuntu:focal \
+		--build-arg LIBTORCH_URL=https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcpu.zip \
+		--build-arg INFERENCE_DEVICE=cpu
+
+.PHONY: run-linux-docker-build
+run-linux-docker-build:
+	docker run --rm -it \
+		-v "$(shell pwd)/cache/Nuitka:/home/user/.cache/Nuitka" \
+		-v "$(shell pwd)/build:/opt/voicevox_engine_build" \
+		hiroshiba/voicevox_engine:build-cpu-ubuntu20.04-latest $(CMD)
+
+
+.PHONY: build-linux-docker-build-nvidia
+build-linux-docker-build-nvidia:
+	docker buildx build . \
+		-t hiroshiba/voicevox_engine:build-nvidia-ubuntu20.04-latest \
+		--target build-env \
+		--progress plain \
+		--build-arg BASE_IMAGE=ubuntu:focal \
+		--build-arg BASE_RUNTIME_IMAGE=nvidia/cuda:11.4.1-cudnn8-runtime-ubuntu20.04 \
+		--build-arg LIBTORCH_URL=https://download.pytorch.org/libtorch/cu111/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcu111.zip \
+		--build-arg INFERENCE_DEVICE=nvidia
 
 .PHONY: run-linux-docker-build-env
 run-linux-docker-build-env:
 	docker run --rm -it \
 		-v "$(shell pwd)/cache/Nuitka:/home/user/.cache/Nuitka" \
 		-v "$(shell pwd)/build:/opt/voicevox_engine_build" \
-		hiroshiba/voicevox_engine:build-env-cpu-ubuntu20.04-latest $(CMD)
+		hiroshiba/voicevox_engine:build-nvidia-ubuntu20.04-latest $(CMD)

--- a/Makefile
+++ b/Makefile
@@ -41,3 +41,19 @@ build-linux-docker-compile-python-env:
 run-linux-docker-compile-python-env:
 	docker run --rm -it \
 		hiroshiba/voicevox_engine:compile-python-env $(CMD)
+
+# Build linux binary in Docker
+.PHONY: build-linux-docker-build-env
+build-linux-docker-build-env:
+	docker buildx build . \
+		-t hiroshiba/voicevox_engine:build-env-cpu-ubuntu20.04-latest \
+		--target build-env \
+		--progress plain \
+		--build-arg BASE_RUNTIME_IMAGE=ubuntu:focal
+
+.PHONY: run-linux-docker-build-env
+run-linux-docker-build-env:
+	docker run --rm -it \
+		-v "$(shell pwd)/cache/Nuitka:/home/user/.cache/Nuitka" \
+		-v "$(shell pwd)/build:/opt/voicevox_engine_build" \
+		hiroshiba/voicevox_engine:build-env-cpu-ubuntu20.04-latest $(CMD)


### PR DESCRIPTION
ref: #95 
ref: #85

## 内容
Docker内でLinux用実行バイナリを自動ビルドするGitHub Workflowを追加します。

run.pyをNuitkaでビルドし、成果物をGitHub ActionsのArtifactとして書き出します。

- 例: https://github.com/aoirint/voicevox_engine/actions/runs/1238234082

ビルドしたバイナリの動作には、CUDA/cuDNN（GPUの場合）とlibsndfileを別途インストールすることが必要です。

```shell
# On Ubuntu 20.04
sudo apt install libsndfile1
```

- CUDA: https://developer.nvidia.com/cuda-downloads
- cuDNN: https://developer.nvidia.com/rdp/cudnn-download

## TODO
- [x] Docker内でLinux用実行バイナリをビルドする
- [x] GitHub Actions上でビルドする
    - 例: https://github.com/aoirint/voicevox_engine/actions/runs/1238234082
- OSベースイメージを変えたDockerコンテナ内、またはUbuntu 20.04以外のLinux OSで動くかテストをする
    - [x] glibc 2.31（ubuntu:focal）でビルドしたバイナリの互換性チェック（glibc 2.29を要求）
        - ✔ Ubuntu 20.04（コンテナ内; glibc 2.31）
        - ❌ Ubuntu 18.04（コンテナ内; glibc 2.27）
        - ✔ Debian 11（コンテナ内; glibc 2.31）
        - ✔ Fedora 34（コンテナ内; glibc 2.33）
        - ❌ CentOS 8（コンテナ内; glibc 2.28）
        - ❌ CentOS Stream 8（コンテナ内; glibc 2.28）
    - [x] glibc 2.27（ubuntu:bionic）でビルドしたバイナリの互換性チェック
        - libcoreの`GLIBCXX_3.4.26`（`libstdc++`）依存のため、ビルドはできるが起動しない
        - libstdc++を更新すれば起動できるが、さまざまなアプリケーションが依存しているOSのコアに近い部分を更新するのは、気軽にできる方法ではないように思う（libstdc++のバージョンは、`strings /usr/lib/x86_64-linux-gnu/libstdc++.so.6 | grep GLIBCXX`に`GLIBCXX_3.4.26`が含まれる必要がある）
        - Ubuntu 18.04でビルドしたlibcoreができ次第、互換性を広げるため再挑戦する予定
            - #98
            - https://github.com/Hiroshiba/voicevox_engine/pull/98#issuecomment-921017757
            - #96 で作成した実行バイナリビルド用DockerイメージをUbuntu 18.04に切り替え
- [x] Nuitka cacheの動作確認
- 実行タイミング
    - [x] masterブランチにpush
    - [x] GitHub Release作成
- [x] masterの変更 f3527e418a902a559dc94ba048b6e9fd9b7b46b1 に追従
    - [x] speakers.jsonを除外 f3527e418a902a559dc94ba048b6e9fd9b7b46b1
    - [x] CPU版ビルド・GPU版ビルドの作成 89fddfefacf72980328fe62e839d2d5bf66606ad
- [x] LibTorch共有ライブラリのコピーを修正（`*.so`に加えて`*.so.*`をコピー）
- [x] libcore.soのLibTorchへのリンクを相対パスに書き換え
- [x] runに実行権限を付与（実装したが、GitHub Artifactの仕様により意味がなかった）
- [x] Artifact名: 固定（バージョン名などを付与すると他のWorkflowやJobから参照できない）
- [x] 76eac98fb0ac36ed40c6169ec75e3715827ac573 動作チェック
    - https://github.com/aoirint/voicevox_engine/actions/runs/1249432164
    - Ubuntu 20.04
        - [x] CPU (`ubuntu:focal`, `9d6a8699fb5c9c39cf08a0871bd6219f0400981c570894cd8cbea30d3424a31f`）
        - [x] GPU (`nvidia/cuda:11.4.1-cudnn8-runtime-ubuntu20.04`, `ddd2828688c94c18b77f095577652faa053052cc40e32b870481087918f04a64`)
    - Debian 11
        - [x] CPU (`debian:stable-20210902`, `a9cb4a9ddf9f28bc17fc390baba42ac7eb067ae54d20b55720ed9ff3323b1d87`)
    - Fedora 34
        - [x] CPU (`fedora:34`, `d18bc88f640bc3e88bbfacaff698c3e1e83cae649019657a3880881f2549a1d0`)
    - Debian 11, Fedora 34のGPU動作（CUDA）については、公式のnvidia/cudaイメージが存在しないため、Docker上で検証するにも自分でメンテナンスする必要があり、また需要がなさそうに思うので、ひとまず対応しない形にする
        - CentOS 8の公式イメージは存在するため、libcoreがCentOS 8（Ubuntu 18.04相当）に対応した際には、あらためて対応する方針
- [x] 対応バージョン・動作環境・実行方法のドキュメント化: #106 （仮）
    - （参考用）CUDAのOS対応表: https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html#system-requirements

## Docker内でビルドする利点
- 環境構築スクリプトを二重に実装する必要がない
    - ちなみに、`autoconf`や`cmake`を使ったビルドスクリプト構築の知見はもっていません
- ビルド環境のキャッシュをDocker Hubに保管できる

（ネイティブビルドの方がよさそうであればCloseするかもです）

## Dockerイメージのpushについて
- `*-buildcache`というビルド環境のキャッシュ用のDockerイメージのみpushします（`--cache-to`オプション）
- バイナリを実行するDockerイメージがあってもいいかもしれませんが、その自動ビルドを実行するGitHub ActionsのJobは、役割的に`build-docker.yml`の方に記述したほうがいいかもしれません
    - 現在の公式Dockerイメージ #88 はnuitkaビルドしていない状態で`run.py`を実行しています
    - ひとまず`build.yml`を実行バイナリビルド用のWorkflowと考えています

## キャッシュについて
- Nuitkaのccacheを使ったCコンパイル部分のキャッシュ機能を利用しようとしています
    - https://nuitka.net/doc/user-manual.html#caching-compilation-results
    - ccacheがインストールされていれば勝手に検出して使われます（Dockerイメージにインストールしています）
    - ccacheによるキャッシュは~/.cache/Nuitka/ccacheに出力されるようです
    - ~/.cache/Nuitka/module-cacheというのもあるので、まとめてキャッシュする予定です（ [actions/cache@v2](https://github.com/actions/cache) を使用）
- GitHub Actionsの実行時ディスク容量は14GB
    - https://docs.github.com/ja/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
    - `docker/build-push-action@v2`の`load: true`というオプションを使っています
        - https://github.com/docker/build-push-action
    - `load: true`により、`docker-container`という仮想化されたDocker環境からDockerイメージを取り出し、あとのstepで使えるようにしているので、イメージサイズの2倍の容量が必要かもしれません
    - つまり、イメージサイズが7GB（14GB/2）に近づくと自動ビルドに失敗するかもしれません
        - これは勘違いかもしれません
