### PR TITLE
Dockerfile (Linux): 各ステージのベースイメージを変更できるようにする

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -21,22 +21,27 @@ jobs:
           - os: ubuntu-latest
             tag: ''
             target: runtime-env
+            base_image: ubuntu:focal
             base_runtime_image: ubuntu:focal
           - os: ubuntu-latest
             tag: cpu
             target: runtime-env
+            base_image: ubuntu:focal
             base_runtime_image: ubuntu:focal
           - os: ubuntu-latest
             tag: cpu-ubuntu20.04
             target: runtime-env
+            base_image: ubuntu:focal
             base_runtime_image: ubuntu:focal
           - os: ubuntu-latest
             tag: nvidia
             target: runtime-nvidia-env
+            base_image: ubuntu:focal
             base_runtime_image: nvidia/cuda:11.4.1-cudnn8-runtime-ubuntu20.04
           - os: ubuntu-latest
             tag: nvidia-ubuntu20.04
             target: runtime-nvidia-env
+            base_image: ubuntu:focal
             base_runtime_image: nvidia/cuda:11.4.1-cudnn8-runtime-ubuntu20.04
 
     steps:
@@ -69,6 +74,7 @@ jobs:
           builder: ${{ steps.buildx.outputs.name }}
           file: ./Dockerfile
           build-args: |
+            BASE_IMAGE=${{ matrix.base_image }}
             BASE_RUNTIME_IMAGE=${{ matrix.base_runtime_image }}
           target: ${{ matrix.target }}
           push: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
 # syntax=docker/dockerfile:1.3-labs
 
+ARG BASE_IMAGE=ubuntu:focal
 ARG BASE_RUNTIME_IMAGE=ubuntu:focal
 
 # Download VOICEVOX Core shared object
-FROM ubuntu:focal AS download-core-env
+FROM ${BASE_IMAGE} AS download-core-env
 ARG DEBIAN_FRONTEND=noninteractive
 
 WORKDIR /work
@@ -33,7 +34,7 @@ EOF
 
 
 # Download LibTorch
-FROM ubuntu:focal AS download-libtorch-env
+FROM ${BASE_IMAGE} AS download-libtorch-env
 ARG DEBIAN_FRONTEND=noninteractive
 
 WORKDIR /work
@@ -63,7 +64,7 @@ EOF
 
 
 # Compile Python (version locked)
-FROM ubuntu:focal AS compile-python-env
+FROM ${BASE_IMAGE} AS compile-python-env
 
 ARG DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
小分けのPull Request（ #97, #98, #99 )で失礼します。まとめた方がよければまとめます。

## 内容
Dockerfile (Linux) の一部ステージのベースイメージが`ubuntu:focal`に固定されていました。
これを`--build-arg`（`ARG`）を使ってイメージビルド時に変更できるようにします。

実行用ステージ（runtime-env）とPythonなどのビルド用ステージのOSバージョンを統一できない問題を解決します。

## 背景
https://github.com/Hiroshiba/voicevox_engine/issues/95#issuecomment-920446490