### PR TITLE
Dockerfile (Linux): インデントの修正・entrypointにshebangを追加・entrypointの処理順交換

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -172,11 +172,11 @@ COPY --from=download-libtorch-env /opt/libtorch /opt/libtorch
 
 ARG VOICEVOX_CORE_EXAMPLE_VERSION=0.5.2
 RUN <<EOF
-  git clone -b "${VOICEVOX_CORE_EXAMPLE_VERSION}" --depth 1 https://github.com/Hiroshiba/voicevox_core.git /opt/voicevox_core_example
-  cd /opt/voicevox_core_example
-  cp ./core.h ./example/python/
-  cd example/python
-  LIBRARY_PATH="/opt/voicevox_core:$LIBRARY_PATH" gosu user /opt/python/bin/pip3 install .
+    git clone -b "${VOICEVOX_CORE_EXAMPLE_VERSION}" --depth 1 https://github.com/Hiroshiba/voicevox_core.git /opt/voicevox_core_example
+    cd /opt/voicevox_core_example
+    cp ./core.h ./example/python/
+    cd example/python
+    LIBRARY_PATH="/opt/voicevox_core:$LIBRARY_PATH" gosu user /opt/python/bin/pip3 install .
 EOF
 
 ADD ./voicevox_engine /opt/voicevox_engine/voicevox_engine
@@ -189,15 +189,15 @@ EOF
 
 # Update ldconfig on container start
 RUN <<EOF
-  cat <<EOT > /entrypoint.sh
-      rm -f /etc/ld.so.cache
-      ldconfig
+    cat <<EOT > /entrypoint.sh
+        rm -f /etc/ld.so.cache
+        ldconfig
 
-      cat /opt/voicevox_core/README.txt > /dev/stderr
+        cat /opt/voicevox_core/README.txt > /dev/stderr
 
-      exec "\$@"
-  EOT
-  chmod +x /entrypoint.sh
+        exec "\$@"
+EOT
+    chmod +x /entrypoint.sh
 EOF
 
 ENTRYPOINT [ "bash", "/entrypoint.sh"  ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -190,6 +190,7 @@ EOF
 # Update ldconfig on container start
 RUN <<EOF
     cat <<EOT > /entrypoint.sh
+        #!/bin/bash
         rm -f /etc/ld.so.cache
         ldconfig
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -191,10 +191,10 @@ EOF
 RUN <<EOF
     cat <<EOT > /entrypoint.sh
         #!/bin/bash
+        cat /opt/voicevox_core/README.txt > /dev/stderr
+
         rm -f /etc/ld.so.cache
         ldconfig
-
-        cat /opt/voicevox_core/README.txt > /dev/stderr
 
         exec "\$@"
 EOT


### PR DESCRIPTION
## 内容

Dockerfile (Linux) の細かな修正です。

- インデントをスペース4個に統一
- heredocにおいて、終端文字列のインデントを削除
    - 終端文字列はインデントをつけると終端文字列として動作しない
        - `/entrypoint.sh`に`EOT`以降の記述が書き込まれる状態になっていた
        - 自動で終了するコマンドを実行した場合、続けて、存在しない`EOT`コマンドを実行しようとして失敗・異常終了する
- entrypointにshebangを追加
    - `ENTRYPOINT [ "/entrypoint.sh" ] `のような書き方ではイメージ実行に失敗したため、実際は使っていない
        - `standard_init_linux.go:228: exec user process caused: exec format error`
    - bashを想定していることを明示するため追加
- entrypointの`ldconfig`をREADME表示後に実行
    - Dockerイメージのデバッグをしやすくする
    - ldconfig実行時にエラーが表示されて、イメージが正しく動作しない例: https://github.com/Hiroshiba/voicevox_engine/pull/98#issuecomment-920488596

