### PR TITLE
Dockerfile (Linux): CPUイメージでLibTorch CPU版を使用

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -22,26 +22,31 @@ jobs:
             tag: ''
             target: runtime-env
             base_runtime_image: ubuntu:focal
+            inference_device: cpu
             libtorch_url: https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcpu.zip
           - os: ubuntu-latest
             tag: cpu
             target: runtime-env
             base_runtime_image: ubuntu:focal
+            inference_device: cpu
             libtorch_url: https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcpu.zip
           - os: ubuntu-latest
             tag: cpu-ubuntu20.04
             target: runtime-env
             base_runtime_image: ubuntu:focal
+            inference_device: cpu
             libtorch_url: https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcpu.zip
           - os: ubuntu-latest
             tag: nvidia
             target: runtime-nvidia-env
             base_runtime_image: nvidia/cuda:11.4.1-cudnn8-runtime-ubuntu20.04
+            inference_device: nvidia
             libtorch_url: https://download.pytorch.org/libtorch/cu111/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcu111.zip
           - os: ubuntu-latest
             tag: nvidia-ubuntu20.04
             target: runtime-nvidia-env
             base_runtime_image: nvidia/cuda:11.4.1-cudnn8-runtime-ubuntu20.04
+            inference_device: nvidia
             libtorch_url: https://download.pytorch.org/libtorch/cu111/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcu111.zip
 
     steps:
@@ -75,6 +80,7 @@ jobs:
           file: ./Dockerfile
           build-args: |
             BASE_RUNTIME_IMAGE=${{ matrix.base_runtime_image }}
+            INFERENCE_DEVICE=${{ matrix.inference_device }}
             LIBTORCH_URL=${{ matrix.libtorch_url }}
           target: ${{ matrix.target }}
           push: true

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -22,22 +22,27 @@ jobs:
             tag: ''
             target: runtime-env
             base_runtime_image: ubuntu:focal
+            libtorch_url: https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcpu.zip
           - os: ubuntu-latest
             tag: cpu
             target: runtime-env
             base_runtime_image: ubuntu:focal
+            libtorch_url: https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcpu.zip
           - os: ubuntu-latest
             tag: cpu-ubuntu20.04
             target: runtime-env
             base_runtime_image: ubuntu:focal
+            libtorch_url: https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcpu.zip
           - os: ubuntu-latest
             tag: nvidia
             target: runtime-nvidia-env
             base_runtime_image: nvidia/cuda:11.4.1-cudnn8-runtime-ubuntu20.04
+            libtorch_url: https://download.pytorch.org/libtorch/cu111/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcu111.zip
           - os: ubuntu-latest
             tag: nvidia-ubuntu20.04
             target: runtime-nvidia-env
             base_runtime_image: nvidia/cuda:11.4.1-cudnn8-runtime-ubuntu20.04
+            libtorch_url: https://download.pytorch.org/libtorch/cu111/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcu111.zip
 
     steps:
       - uses: actions/checkout@v2
@@ -70,6 +75,7 @@ jobs:
           file: ./Dockerfile
           build-args: |
             BASE_RUNTIME_IMAGE=${{ matrix.base_runtime_image }}
+            LIBTORCH_URL=${{ matrix.libtorch_url }}
           target: ${{ matrix.target }}
           push: true
           tags: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ RUN <<EOF
     rm -rf /var/lib/apt/lists/*
 EOF
 
-ARG LIBTORCH_URL=https://download.pytorch.org/libtorch/cu111/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcu111.zip
+ARG LIBTORCH_URL=https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcpu.zip
 RUN <<EOF
     wget -nv --show-progress -c -O "./libtorch.zip" "${LIBTORCH_URL}"
     unzip "./libtorch.zip"

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,8 +33,9 @@ EOF
 
 # Temporary workaround: modify libcore link for cpu
 # Remove CUDA/LibTorchGPU dependencies from libcore
+ARG INFERENCE_DEVICE=cpu
 RUN <<EOF
-    if [ "$(echo ${BASE_RUNTIME_IMAGE} | cut -c 1-11)" != nvidia/cuda ]; then
+    if [ "${INFERENCE_DEVICE}" = "cpu" ]; then
         apt-get update
         apt-get install -y \
             patchelf
@@ -44,7 +45,7 @@ RUN <<EOF
 EOF
 
 RUN <<EOF
-    if [ "$(echo ${BASE_RUNTIME_IMAGE} | cut -c 1-11)" != nvidia/cuda ]; then
+    if [ "${INFERENCE_DEVICE}" = "cpu" ]; then
         cd /opt/voicevox_core/
 
         patchelf --remove-needed libtorch_cuda.so libcore.so

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,6 @@ FROM ubuntu:focal AS download-core-env
 ARG DEBIAN_FRONTEND=noninteractive
 
 WORKDIR /work
-SHELL [ "/bin/bash" ]
 
 RUN <<EOF
     apt-get update
@@ -35,7 +34,7 @@ EOF
 # Temporary workaround: modify libcore link for cpu
 # Remove CUDA/LibTorchGPU dependencies from libcore
 RUN <<EOF
-    if [[ ! "${BASE_RUNTIME_IMAGE}" ~= '^nvidia/cuda.*' ]]; then
+    if [ "${BASE_RUNTIME_IMAGE:0:11}" != nvidia/cuda ]; then
         apt-get update
         apt-get install -y \
             patchelf
@@ -45,15 +44,15 @@ RUN <<EOF
 EOF
 
 RUN <<EOF
-  if [[ ! "${BASE_RUNTIME_IMAGE}" ~= '^nvidia/cuda.*' ]]; then
-    cd /opt/voicevox_core/
+    if [ "${BASE_RUNTIME_IMAGE:0:11}" != nvidia/cuda ]; then
+        cd /opt/voicevox_core/
 
-    patchelf --remove-needed libtorch_cuda.so libcore.so
-    patchelf --remove-needed libtorch_cuda_cpp.so libcore.so
-    patchelf --remove-needed libtorch_cuda_cu.so libcore.so
-    patchelf --remove-needed libnvToolsExt.so.1 libcore.so
-    patchelf --remove-needed libcudart.so.11.0 libcore.so
-  fi
+        patchelf --remove-needed libtorch_cuda.so libcore.so
+        patchelf --remove-needed libtorch_cuda_cpp.so libcore.so
+        patchelf --remove-needed libtorch_cuda_cu.so libcore.so
+        patchelf --remove-needed libnvToolsExt.so.1 libcore.so
+        patchelf --remove-needed libcudart.so.11.0 libcore.so
+    fi
 EOF
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ FROM ubuntu:focal AS download-core-env
 ARG DEBIAN_FRONTEND=noninteractive
 
 WORKDIR /work
+SHELL [ "/bin/bash" ]
 
 RUN <<EOF
     apt-get update

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ EOF
 # Temporary workaround: modify libcore link for cpu
 # Remove CUDA/LibTorchGPU dependencies from libcore
 RUN <<EOF
-    if [ "${BASE_RUNTIME_IMAGE:0:11}" != nvidia/cuda ]; then
+    if [ "$(echo ${BASE_RUNTIME_IMAGE} | cut -c 1-11)" != nvidia/cuda ]; then
         apt-get update
         apt-get install -y \
             patchelf
@@ -44,7 +44,7 @@ RUN <<EOF
 EOF
 
 RUN <<EOF
-    if [ "${BASE_RUNTIME_IMAGE:0:11}" != nvidia/cuda ]; then
+    if [ "$(echo ${BASE_RUNTIME_IMAGE} | cut -c 1-11)" != nvidia/cuda ]; then
         cd /opt/voicevox_core/
 
         patchelf --remove-needed libtorch_cuda.so libcore.so

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,8 @@ build-linux-docker-ubuntu:
 		--target runtime-env \
 		--progress plain \
 		--build-arg BASE_RUNTIME_IMAGE=ubuntu:focal \
-		--build-arg LIBTORCH_URL=https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcpu.zip
+		--build-arg LIBTORCH_URL=https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcpu.zip \
+		--build-arg INFERENCE_DEVICE=cpu
 
 .PHONY: run-linux-docker-ubuntu
 run-linux-docker-ubuntu:
@@ -22,7 +23,8 @@ build-linux-docker-nvidia:
 		--target runtime-nvidia-env \
 		--progress plain \
 		--build-arg BASE_RUNTIME_IMAGE=nvidia/cuda:11.4.1-cudnn8-runtime-ubuntu20.04 \
-		--build-arg LIBTORCH_URL=https://download.pytorch.org/libtorch/cu111/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcu111.zip
+		--build-arg LIBTORCH_URL=https://download.pytorch.org/libtorch/cu111/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcu111.zip \
+		--build-arg INFERENCE_DEVICE=nvidia
 
 .PHONY: run-linux-docker-nvidia
 run-linux-docker-nvidia:

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,8 @@ build-linux-docker-ubuntu:
 		-t hiroshiba/voicevox_engine:cpu-ubuntu20.04-latest \
 		--target runtime-env \
 		--progress plain \
-		--build-arg BASE_RUNTIME_IMAGE=ubuntu:focal
+		--build-arg BASE_RUNTIME_IMAGE=ubuntu:focal \
+		--build-arg LIBTORCH_URL=https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcpu.zip
 
 .PHONY: run-linux-docker-ubuntu
 run-linux-docker-ubuntu:
@@ -20,7 +21,8 @@ build-linux-docker-nvidia:
 		-t hiroshiba/voicevox_engine:nvidia-ubuntu20.04-latest \
 		--target runtime-nvidia-env \
 		--progress plain \
-		--build-arg BASE_RUNTIME_IMAGE=nvidia/cuda:11.4.1-cudnn8-runtime-ubuntu20.04
+		--build-arg BASE_RUNTIME_IMAGE=nvidia/cuda:11.4.1-cudnn8-runtime-ubuntu20.04 \
+		--build-arg LIBTORCH_URL=https://download.pytorch.org/libtorch/cu111/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcu111.zip
 
 .PHONY: run-linux-docker-nvidia
 run-linux-docker-nvidia:


### PR DESCRIPTION
CPU用のDockerイメージでLibTorch CPU版を使用するようにします。

CPU用のDockerイメージを軽量化（おおよそ1/3: 2.85GB→1.01GB）できます。

VOICEVOX CORE 0.5.2現在、`libcore.so`のCUDA/LibTorch GPU版に依存しない版が存在しないため、`patchelf`を使って共有ライブラリのリンクを削除するWorkaroundを実装しています。

CPU版がリリースされたとき、Workaroundを削除するパッチをマージするのがよさそうです。

## `libcore.so`の`libtorch_cuda.so`依存（Workaroundで解消）

```shell
# docker run --rm -it -p '127.0.0.1:50021:50021' aoirint/voicevox_engine:cpu-ubuntu20.04-0.5.2-aoirint-6
...
Notice: --voicevox_dir is /opt/voicevox_core
Traceback (most recent call last):
  File "./run.py", line 56, in make_synthesis_engine
    import core
ImportError: libtorch_cuda.so: cannot open shared object file: No such file or directory
Notice: mock-library will be used. Try re-run with valid --voicevox_dir
```

## 動作例

```shell
docker run --rm -it -p '127.0.0.1:50021:50021' aoirint/voicevox_engine:cpu-ubuntu20.04-0.5.2-aoirint-10
```
