### PR TITLE
coreのspeakers情報を使うように変更

### DIFF
--- a/run.py
+++ b/run.py
@@ -79,6 +79,7 @@ def make_synthesis_engine(
             yukarin_s_forwarder=core.yukarin_s_forward,
             yukarin_sa_forwarder=core.yukarin_sa_forward,
             decode_forwarder=core.decode_forward,
+            speakers=core.metas(),
         )
 
     from voicevox_engine.dev.synthesis_engine import (
@@ -312,9 +313,8 @@ def generate_app(engine: SynthesisEngine) -> FastAPI:
 
     @app.get("/speakers", response_model=List[Speaker], tags=["その他"])
     def speakers():
-        # TODO 音声ライブラリのAPIが出来たら差し替える
         return Response(
-            content=(root_dir / "speakers.json").read_text("utf-8"),
+            content=engine.speakers,
             media_type="application/json",
         )
 

--- a/voicevox_engine/dev/core/__init__.py
+++ b/voicevox_engine/dev/core/__init__.py
@@ -1,3 +1,15 @@
-from .mock import decode_forward, initialize, yukarin_s_forward, yukarin_sa_forward, metas
+from .mock import (
+    decode_forward,
+    initialize,
+    metas,
+    yukarin_s_forward,
+    yukarin_sa_forward,
+)
 
-__all__ = ["decode_forward", "initialize", "yukarin_s_forward", "yukarin_sa_forward", "metas"]
+__all__ = [
+    "decode_forward",
+    "initialize",
+    "yukarin_s_forward",
+    "yukarin_sa_forward",
+    "metas",
+]

--- a/voicevox_engine/dev/core/__init__.py
+++ b/voicevox_engine/dev/core/__init__.py
@@ -1,3 +1,3 @@
-from .mock import decode_forward, initialize, yukarin_s_forward, yukarin_sa_forward
+from .mock import decode_forward, initialize, yukarin_s_forward, yukarin_sa_forward, metas
 
-__all__ = ["decode_forward", "initialize", "yukarin_s_forward", "yukarin_sa_forward"]
+__all__ = ["decode_forward", "initialize", "yukarin_s_forward", "yukarin_sa_forward", "metas"]

--- a/voicevox_engine/dev/core/mock.py
+++ b/voicevox_engine/dev/core/mock.py
@@ -71,4 +71,4 @@ def decode_forward(length: int, **kwargs: Dict[str, Any]) -> np.ndarray:
 
 
 def metas() -> str:
-    return "[{\"name\": \"dummy1\", \"speaker_id\": 0},{\"name\": \"dummy2\", \"speaker_id\": 1}]"
+    return '[{"name": "dummy1", "speaker_id": 0},{"name": "dummy2", "speaker_id": 1}]'

--- a/voicevox_engine/dev/core/mock.py
+++ b/voicevox_engine/dev/core/mock.py
@@ -69,5 +69,6 @@ def decode_forward(length: int, **kwargs: Dict[str, Any]) -> np.ndarray:
     )
     return wave
 
+
 def metas() -> str:
-    return "[]"
+    return "[{\"name\": \"dummy1\", \"speaker_id\": 0},{\"name\": \"dummy2\", \"speaker_id\": 1}]"

--- a/voicevox_engine/dev/core/mock.py
+++ b/voicevox_engine/dev/core/mock.py
@@ -68,3 +68,6 @@ def decode_forward(length: int, **kwargs: Dict[str, Any]) -> np.ndarray:
         filter="kaiser_fast",
     )
     return wave
+
+def metas() -> str:
+    return "[]"

--- a/voicevox_engine/dev/synthesis_engine/mock.py
+++ b/voicevox_engine/dev/synthesis_engine/mock.py
@@ -19,6 +19,7 @@ class SynthesisEngine:
         __init__ [Mock]
         """
         super().__init__()
+        self.speakers = "[]"
 
     def replace_phoneme_length(
         self, accent_phrases: List[AccentPhrase], speaker_id: int

--- a/voicevox_engine/dev/synthesis_engine/mock.py
+++ b/voicevox_engine/dev/synthesis_engine/mock.py
@@ -20,9 +20,10 @@ class SynthesisEngine:
         """
         super().__init__()
 
-        self.speakers = "[{\"name\": \"dummy1\", \"speaker_id\": 0},{\"name\": \"dummy2\", \"speaker_id\": 1}]"
+        self.speakers = (
+            '[{"name": "dummy1", "speaker_id": 0},{"name": "dummy2", "speaker_id": 1}]'
+        )
         self.default_sampling_rate = 24000
-
 
     def replace_phoneme_length(
         self, accent_phrases: List[AccentPhrase], speaker_id: int

--- a/voicevox_engine/dev/synthesis_engine/mock.py
+++ b/voicevox_engine/dev/synthesis_engine/mock.py
@@ -19,7 +19,7 @@ class SynthesisEngine:
         __init__ [Mock]
         """
         super().__init__()
-        self.speakers = "[]"
+        self.speakers = "[{\"name\": \"dummy1\", \"speaker_id\": 0},{\"name\": \"dummy2\", \"speaker_id\": 1}]"
 
     def replace_phoneme_length(
         self, accent_phrases: List[AccentPhrase], speaker_id: int

--- a/voicevox_engine/synthesis_engine.py
+++ b/voicevox_engine/synthesis_engine.py
@@ -64,7 +64,7 @@ class SynthesisEngine:
         yukarin_s_forwarder,
         yukarin_sa_forwarder,
         decode_forwarder,
-        speakers,
+        speakers: str,
     ):
         """
         yukarin_s_forwarder: 音素列から、音素ごとの長さを求める関数

--- a/voicevox_engine/synthesis_engine.py
+++ b/voicevox_engine/synthesis_engine.py
@@ -63,6 +63,7 @@ class SynthesisEngine:
         yukarin_s_forwarder,
         yukarin_sa_forwarder,
         decode_forwarder,
+        speakers,
     ):
         """
         yukarin_s_forwarder: 音素列から、音素ごとの長さを求める関数
@@ -89,6 +90,8 @@ class SynthesisEngine:
             phoneme: フレームごとの音素
             speaker_id: 話者番号
             return: 音声波形
+
+        speakers: coreから取得したspeakersに関するjsonデータの文字列
         """
         super().__init__()
         self.yukarin_s_forwarder = yukarin_s_forwarder
@@ -96,6 +99,7 @@ class SynthesisEngine:
         self.decode_forwarder = decode_forwarder
         self.yukarin_s_phoneme_class = OjtPhoneme
         self.yukarin_soso_phoneme_class = OjtPhoneme
+        self.speakers = speakers
 
     def replace_phoneme_length(
         self, accent_phrases: List[AccentPhrase], speaker_id: int

--- a/voicevox_engine/synthesis_engine.py
+++ b/voicevox_engine/synthesis_engine.py
@@ -104,7 +104,6 @@ class SynthesisEngine:
         self.speakers = speakers
         self.default_sampling_rate = 24000
 
-
     def replace_phoneme_length(
         self, accent_phrases: List[AccentPhrase], speaker_id: int
     ) -> List[AccentPhrase]:


### PR DESCRIPTION
close #90 

https://github.com/Hiroshiba/voicevox_engine/pull/92#issuecomment-920040723

ここで言及したものから、mockの方の情報にダミーのものを追加
またpysenのテストが通るように修正