### PR TITLE
Windows用実行バイナリの自動ビルドを追加 (#85)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -186,15 +186,15 @@ jobs:
         id: voicevox-core-cache
         with:
           key: ${{ matrix.os }}-voicevox-core-${{ hashFiles('download/voicevox_core_url.txt') }}
-          path: download/voicevox_core
+          path: download/core
 
       - name: Download VOICEVOX Core
         if: steps.voicevox-core-cache.outputs.cache-hit != 'true'
         shell: bash
         run: |
-          curl -L "${{ matrix.voicevox_core_url }}" > download/voicevox_core.zip
-          unzip download/voicevox_core.zip -d download/
-          rm download/voicevox_core.zip
+          curl -L "${{ matrix.voicevox_core_url }}" > download/core.zip
+          unzip download/core.zip -d download/
+          rm download/core.zip
 
       # Setup CUDA
       - name: Setup CUDA

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,3 +109,139 @@ jobs:
         with:
           name: ${{ matrix.artifact_name }}
           path: build/run.dist/
+
+
+  build-windows:
+    strategy:
+      matrix:
+        device:
+          - 'cpu'
+          - 'nvidia'
+        python:
+          - '3.7'
+        python_architecture:
+          - 'x64'
+        cuda_version:
+          - '11.1.1'
+        include:
+        - os: windows-latest
+          device: cpu
+          voicevox_core_url: https://github.com/Hiroshiba/voicevox_core/releases/download/0.5.2/core.zip
+          libtorch_url: https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcpu.zip
+          cudnn_url: https://developer.download.nvidia.com/compute/redist/cudnn/v8.0.5/cudnn-11.1-windows-x64-v8.0.5.39.zip
+          artifact_name: windows-cpu
+          nuitka_cache_path: nuitka_cache
+          pip_cache_path: ~\AppData\Local\pip\Cache
+        - os: windows-latest
+          device: nvidia
+          voicevox_core_url: https://github.com/Hiroshiba/voicevox_core/releases/download/0.5.2/core.zip
+          libtorch_url: https://download.pytorch.org/libtorch/cu111/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcu111.zip
+          cudnn_url: https://developer.download.nvidia.com/compute/redist/cudnn/v8.0.5/cudnn-11.1-windows-x64-v8.0.5.39.zip
+          artifact_name: windows-nvidia
+          nuitka_cache_path: nuitka_cache
+          pip_cache_path: ~\AppData\Local\pip\Cache
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup MSVC
+        if: startsWith(matrix.os, 'windows')
+        uses: ilammy/msvc-dev-cmd@v1
+
+      # Python install path: C:/hostedtoolcache/windows/Python
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python }}
+          architecture: ${{ matrix.python_architecture }}
+
+      # Install Python dependencies
+      - name: Prepare Python dependencies cache
+        uses: actions/cache@v2
+        id: pip-cache
+        with:
+          path: ${{ matrix.pip_cache_path }}
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt', '**/requirements-dev.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip setuptools wheel
+          pip install -r requirements-dev.txt
+
+      - name: Create download directory
+        shell: bash
+        run: mkdir -p download/
+
+      # Download VOICEVOX Core
+      - name: Export VOICEVOX Core url to calc hash
+        shell: bash
+        run: echo "${{ matrix.voicevox_core_url }}" > download/voicevox_core_url.txt
+
+      - name: Prepare VOICEVOX Core cache
+        uses: actions/cache@v2
+        id: voicevox-core-cache
+        with:
+          key: ${{ matrix.os }}-voicevox-core-${{ hashFiles('download/voicevox_core_url.txt') }}
+          path: download/voicevox_core
+
+      - name: Download VOICEVOX Core
+        if: steps.voicevox-core-cache.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          curl -L "${{ matrix.voicevox_core_url }}" > download/voicevox_core.zip
+          unzip download/voicevox_core.zip -d download/
+          rm download/voicevox_core.zip
+
+      # Setup CUDA
+      - name: Setup CUDA
+        if: matrix.device == 'nvidia'
+        uses: Jimver/cuda-toolkit@v0.2.4
+        id: cuda-toolkit
+        with:
+          method: network
+          cuda: ${{ matrix.cuda_version }}
+
+      # Download cuDNN
+      - name: Export cuDNN url to calc hash
+        shell: bash
+        run: echo "${{ matrix.cudnn_url }}" > download/cudnn_url.txt
+
+      - name: Prepare cuDNN cache
+        if: matrix.device == 'nvidia'
+        uses: actions/cache@v2
+        id: cudnn-cache
+        with:
+          key: ${{ matrix.os }}-cudnn-${{ hashFiles('download/cudnn_url.txt') }}
+          path: download/cudnn
+
+      - name: Download cuDNN
+        if: matrix.device == 'nvidia' && steps.cudnn-cache.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          curl -L "${{ matrix.cudnn_url }}" > download/cudnn.zip
+          unzip download/cudnn.zip -d download/cudnn
+          rm download/cudnn.zip
+
+      # Download LibTorch
+      - name: Export LibTorch url to calc hash
+        shell: bash
+        run: echo "${{ matrix.libtorch_url }}" > download/libtorch_url.txt
+
+      - name: Prepare LibTorch cache
+        uses: actions/cache@v2
+        id: libtorch-cache
+        with:
+          key: ${{ matrix.os }}-libtorch-${{ hashFiles('download/libtorch_url.txt') }}
+          path: download/libtorch
+
+      - name: Download LibTorch
+        if: steps.libtorch-cache.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          curl -L "${{ matrix.libtorch_url }}" > download/libtorch.zip
+          unzip download/libtorch.zip -d download/
+          rm download/libtorch.zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -271,7 +271,7 @@ jobs:
             --include-package-data=resampy
             --include-data-file=VERSION.txt=./
             ${{ (matrix.device == 'nvidia' && env.CUDA_ARGS) || '' }}
-            --include-data-file=download/libtorch/*.dll=./
+            --include-data-file=download/libtorch/lib/*.dll=./
             --include-data-file=download/core/*.bin=./
             --include-data-file=download/core/metas.json=./
             --include-data-dir=C:/hostedtoolcache/windows/Python/Lib/site-packages/_soundfile_data=./_soundfile_data

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -256,6 +256,7 @@ jobs:
             ${{ runner.os }}-nuitka-${{ matrix.target }}-
 
       - name: Build run.py with Nuitka
+        shell: bash
         env:
           CUDA_ARGS:
             --include-data-file=${{ steps.cuda-toolkit.outputs.CUDA_PATH }}/*.dll=./
@@ -274,8 +275,8 @@ jobs:
             --include-data-file=download/libtorch/lib/*.dll=./
             --include-data-file=download/core/*.bin=./
             --include-data-file=download/core/metas.json=./
-            --include-data-dir=C:/hostedtoolcache/windows/Python/Lib/site-packages/_soundfile_data=./_soundfile_data
-            --include-data-file=C:/hostedtoolcache/windows/Python/Lib/site-packages/llvmlite/binding/llvmlite.dll=./
+            --include-data-dir=C:/hostedtoolcache/windows/python/3.7.9/x64/lib/site-packages/_soundfile_data=./_soundfile_data
+            --include-data-file=C:/hostedtoolcache/windows/python/3.7.9/x64/lib/site-packages/llvmlite/binding/llvmlite.dll=./
             --msvc=14.2
             --follow-imports
             --no-prefer-source-code

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -127,7 +127,7 @@ jobs:
         - os: windows-latest
           device: cpu
           voicevox_core_url: https://github.com/Hiroshiba/voicevox_core/releases/download/0.5.2/core.zip
-          libtorch_url: https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcpu.zip
+          libtorch_url: https://download.pytorch.org/libtorch/cpu/libtorch-win-shared-with-deps-1.9.0%2Bcpu.zip
           cudnn_url: https://developer.download.nvidia.com/compute/redist/cudnn/v8.0.5/cudnn-11.1-windows-x64-v8.0.5.39.zip
           artifact_name: windows-cpu
           nuitka_cache_path: nuitka_cache
@@ -135,7 +135,7 @@ jobs:
         - os: windows-latest
           device: nvidia
           voicevox_core_url: https://github.com/Hiroshiba/voicevox_core/releases/download/0.5.2/core.zip
-          libtorch_url: https://download.pytorch.org/libtorch/cu111/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcu111.zip
+          libtorch_url: https://download.pytorch.org/libtorch/cu111/libtorch-win-shared-with-deps-1.9.0%2Bcu111.zip
           cudnn_url: https://developer.download.nvidia.com/compute/redist/cudnn/v8.0.5/cudnn-11.1-windows-x64-v8.0.5.39.zip
           artifact_name: windows-nvidia
           nuitka_cache_path: nuitka_cache
@@ -245,3 +245,52 @@ jobs:
           curl -L "${{ matrix.libtorch_url }}" > download/libtorch.zip
           unzip download/libtorch.zip -d download/
           rm download/libtorch.zip
+
+      - name: Cache Nuitka (ccache, module-cache)
+        uses: actions/cache@v2
+        id: nuitka-cache
+        with:
+          path: ${{ matrix.nuitka_cache_path }}
+          key: ${{ runner.os }}-nuitka-${{ matrix.target }}-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-nuitka-${{ matrix.target }}-
+
+      - name: Build run.py with Nuitka
+        env:
+          CUDA_ARGS:
+            --include-data-file=${{ steps.cuda-toolkit.outputs.CUDA_PATH }}/*.dll=./
+            --include-data-file=download/cudnn/cuda/*.dll=./
+        run:
+          python -m nuitka
+            --standalone
+            --plugin-enable=numpy
+            --follow-import-to=numpy
+            --follow-import-to=aiofiles
+            --include-package=uvicorn
+            --include-package-data=pyopenjtalk
+            --include-package-data=resampy
+            --include-data-file=VERSION.txt=./
+            ${{ (matrix.device == 'nvidia' && env.CUDA_ARGS) || '' }}
+            --include-data-file=download/libtorch/*.dll=./
+            --include-data-file=download/core/*.bin=./
+            --include-data-file=download/core/metas.json=./
+            --include-data-dir=C:/hostedtoolcache/windows/Python/Lib/site-packages/_soundfile_data=./_soundfile_data
+            --include-data-file=C:/hostedtoolcache/windows/Python/Lib/site-packages/llvmlite/binding/llvmlite.dll=./
+            --msvc=14.2
+            --follow-imports
+            --no-prefer-source-code
+            run.py
+
+      # FIXME: versioned name may be useful; but
+      # actions/download-artifact and dawidd6/download-artifact do not support
+      # wildcard / forward-matching yet.
+      # Currently, It is good to use static artifact name for future binary test workflow.
+      # https://github.com/actions/toolkit/blob/ea81280a4d48fb0308d40f8f12ae00d117f8acb9/packages/artifact/src/internal/artifact-client.ts#L147
+      # https://github.com/dawidd6/action-download-artifact/blob/af92a8455a59214b7b932932f2662fdefbd78126/main.js#L113
+      - uses: actions/upload-artifact@v2
+        # env:
+        #   VERSIONED_ARTIFACT_NAME: |
+        #     ${{ format('{0}-{1}', matrix.artifact_name, (github.event.release.tag_name != '' && github.event.release.tag_name) || github.sha) }}
+        with:
+          name: ${{ matrix.artifact_name }}
+          path: run.dist/


### PR DESCRIPTION
ref: #85 

Windows用実行バイナリを自動ビルドするGitHub Workflowを追加します。

run.pyをNuitkaでビルドし、成果物をGitHub ActionsのArtifactとして書き出します。

CUDA/cuDNN、LibTorchを同梱します。GPU版のNVIDIA Driverを除き、追加の依存関係はありません。
