### PR TITLE
Docker Linux: VOICEVOX CORE 0.6.0に追従

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -1,8 +1,8 @@
 name: build-docker
 on:
   push:
-    branches:
-      - master
+    # branches:
+    #   - master
   release:
     types:
       - created
@@ -22,27 +22,32 @@ jobs:
         voicevox_core_version: [0.6.0]
         voicevox_core_example_version: [0.6.0]
         include:
-          - tag: ''
+          - os: ubuntu-latest
+            tag: ''
             target: runtime-env
             base_runtime_image: ubuntu:focal
             voicevox_core_library_name: core_cpu
             libtorch_url: https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcpu.zip
-          - tag: cpu
+          - os: ubuntu-latest
+            tag: cpu
             target: runtime-env
             base_runtime_image: ubuntu:focal
             voicevox_core_library_name: core_cpu
             libtorch_url: https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcpu.zip
-          - tag: cpu-ubuntu20.04
+          - os: ubuntu-latest
+            tag: cpu-ubuntu20.04
             target: runtime-env
             base_runtime_image: ubuntu:focal
             voicevox_core_library_name: core_cpu
             libtorch_url: https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcpu.zip
-          - tag: nvidia
+          - os: ubuntu-latest
+            tag: nvidia
             target: runtime-nvidia-env
             base_runtime_image: nvidia/cuda:11.4.1-cudnn8-runtime-ubuntu20.04
             voicevox_core_library_name: core
             libtorch_url: https://download.pytorch.org/libtorch/cu111/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcu111.zip
-          - tag: nvidia-ubuntu20.04
+          - os: ubuntu-latest
+            tag: nvidia-ubuntu20.04
             target: runtime-nvidia-env
             base_runtime_image: nvidia/cuda:11.4.1-cudnn8-runtime-ubuntu20.04
             voicevox_core_library_name: core

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -25,27 +25,27 @@ jobs:
           - tag: ''
             target: runtime-env
             base_runtime_image: ubuntu:focal
-            voicevox_core_so_name: libcore_cpu.so
+            voicevox_core_library_name: core_cpu
             libtorch_url: https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcpu.zip
           - tag: cpu
             target: runtime-env
             base_runtime_image: ubuntu:focal
-            voicevox_core_so_name: libcore_cpu.so
+            voicevox_core_library_name: core_cpu
             libtorch_url: https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcpu.zip
           - tag: cpu-ubuntu20.04
             target: runtime-env
             base_runtime_image: ubuntu:focal
-            voicevox_core_so_name: libcore_cpu.so
+            voicevox_core_library_name: core_cpu
             libtorch_url: https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcpu.zip
           - tag: nvidia
             target: runtime-nvidia-env
             base_runtime_image: nvidia/cuda:11.4.1-cudnn8-runtime-ubuntu20.04
-            voicevox_core_so_name: libcore.so
+            voicevox_core_library_name: core
             libtorch_url: https://download.pytorch.org/libtorch/cu111/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcu111.zip
           - tag: nvidia-ubuntu20.04
             target: runtime-nvidia-env
             base_runtime_image: nvidia/cuda:11.4.1-cudnn8-runtime-ubuntu20.04
-            voicevox_core_so_name: libcore.so
+            voicevox_core_library_name: core
             libtorch_url: https://download.pytorch.org/libtorch/cu111/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcu111.zip
 
     steps:
@@ -82,7 +82,7 @@ jobs:
             BASE_RUNTIME_IMAGE=${{ matrix.base_runtime_image }}
             VOICEVOX_CORE_VERSION=${{ matrix.voicevox_core_version }}
             VOICEVOX_CORE_EXAMPLE_VERSION=${{ matrix.voicevox_core_example_version }}
-            VOICEVOX_CORE_SO_NAME=${{ matrix.voicevox_core_so_name }}
+            VOICEVOX_CORE_LIBRARY_NAME=${{ matrix.voicevox_core_library_name }}
             LIBTORCH_URL=${{ matrix.libtorch_url }}
           target: ${{ matrix.target }}
           push: true

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -17,7 +17,12 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        tag:
+          - ''
+          - cpu
+          - cpu-ubuntu20.04
+          - nvidia
+          - nvidia-ubuntu20.04
         voicevox_core_version: [0.6.0]
         voicevox_core_example_version: [0.6.0]
         include:

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -81,8 +81,8 @@ jobs:
             BASE_IMAGE=${{ matrix.base_image }}
             BASE_RUNTIME_IMAGE=${{ matrix.base_runtime_image }}
             VOICEVOX_CORE_VERSION=${{ matrix.voicevox_core_version }}
-            VOICEVOX_CORE_LIBRARY_NAME=${{ matrix.voicevox_core_library_name }}
             VOICEVOX_CORE_EXAMPLE_VERSION=${{ matrix.voicevox_core_example_version }}
+            VOICEVOX_CORE_LIBRARY_NAME=${{ matrix.voicevox_core_library_name }}
             LIBTORCH_URL=${{ matrix.libtorch_url }}
           target: ${{ matrix.target }}
           push: true

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -25,27 +25,27 @@ jobs:
           - tag: ''
             target: runtime-env
             base_runtime_image: ubuntu:focal
-            inference_device: cpu
+            voicevox_core_so_name: libcore_cpu.so
             libtorch_url: https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcpu.zip
           - tag: cpu
             target: runtime-env
             base_runtime_image: ubuntu:focal
-            inference_device: cpu
+            voicevox_core_so_name: libcore_cpu.so
             libtorch_url: https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcpu.zip
           - tag: cpu-ubuntu20.04
             target: runtime-env
             base_runtime_image: ubuntu:focal
-            inference_device: cpu
+            voicevox_core_so_name: libcore_cpu.so
             libtorch_url: https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcpu.zip
           - tag: nvidia
             target: runtime-nvidia-env
             base_runtime_image: nvidia/cuda:11.4.1-cudnn8-runtime-ubuntu20.04
-            inference_device: nvidia
+            voicevox_core_so_name: libcore.so
             libtorch_url: https://download.pytorch.org/libtorch/cu111/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcu111.zip
           - tag: nvidia-ubuntu20.04
             target: runtime-nvidia-env
             base_runtime_image: nvidia/cuda:11.4.1-cudnn8-runtime-ubuntu20.04
-            inference_device: nvidia
+            voicevox_core_so_name: libcore.so
             libtorch_url: https://download.pytorch.org/libtorch/cu111/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcu111.zip
 
     steps:
@@ -82,7 +82,7 @@ jobs:
             BASE_RUNTIME_IMAGE=${{ matrix.base_runtime_image }}
             VOICEVOX_CORE_VERSION=${{ matrix.voicevox_core_version }}
             VOICEVOX_CORE_EXAMPLE_VERSION=${{ matrix.voicevox_core_example_version }}
-            INFERENCE_DEVICE=${{ matrix.inference_device }}
+            VOICEVOX_CORE_SO_NAME=${{ matrix.voicevox_core_so_name }}
             LIBTORCH_URL=${{ matrix.libtorch_url }}
           target: ${{ matrix.target }}
           push: true

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -17,39 +17,55 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest]
-        base_image: ['ubuntu:focal']
-        voicevox_core_version: [0.6.0]
-        voicevox_core_example_version: [0.6.0]
         include:
-          - os: ubuntu-latest
+          -
+            os: ubuntu-latest
             tag: ''
             target: runtime-env
+            base_image: ubuntu:focal
             base_runtime_image: ubuntu:focal
+            voicevox_core_version: 0.6.0
+            voicevox_core_example_version: 0.6.0
             voicevox_core_library_name: core_cpu
             libtorch_url: https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcpu.zip
-          - os: ubuntu-latest
+          -
+            os: ubuntu-latest
             tag: cpu
             target: runtime-env
+            base_image: ubuntu:focal
             base_runtime_image: ubuntu:focal
+            voicevox_core_version: 0.6.0
+            voicevox_core_example_version: 0.6.0
             voicevox_core_library_name: core_cpu
             libtorch_url: https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcpu.zip
-          - os: ubuntu-latest
+          -
+            os: ubuntu-latest
             tag: cpu-ubuntu20.04
             target: runtime-env
+            base_image: ubuntu:focal
             base_runtime_image: ubuntu:focal
+            voicevox_core_version: 0.6.0
+            voicevox_core_example_version: 0.6.0
             voicevox_core_library_name: core_cpu
             libtorch_url: https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcpu.zip
-          - os: ubuntu-latest
+          -
+            os: ubuntu-latest
             tag: nvidia
             target: runtime-nvidia-env
+            base_image: ubuntu:focal
             base_runtime_image: nvidia/cuda:11.4.1-cudnn8-runtime-ubuntu20.04
+            voicevox_core_version: 0.6.0
+            voicevox_core_example_version: 0.6.0
             voicevox_core_library_name: core
             libtorch_url: https://download.pytorch.org/libtorch/cu111/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcu111.zip
-          - os: ubuntu-latest
+          -
+            os: ubuntu-latest
             tag: nvidia-ubuntu20.04
             target: runtime-nvidia-env
+            base_image: ubuntu:focal
             base_runtime_image: nvidia/cuda:11.4.1-cudnn8-runtime-ubuntu20.04
+            voicevox_core_version: 0.6.0
+            voicevox_core_example_version: 0.6.0
             voicevox_core_library_name: core
             libtorch_url: https://download.pytorch.org/libtorch/cu111/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcu111.zip
 

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        base_image: [ubuntu:focal]
+        base_image: ['ubuntu:focal']
         voicevox_core_version: [0.6.0]
         voicevox_core_example_version: [0.6.0]
         include:

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -17,14 +17,14 @@ jobs:
 
     strategy:
       matrix:
+        voicevox_core_version: [0.6.0]
+        voicevox_core_example_version: [0.6.0]
         include:
           - os: ubuntu-latest
             tag: ''
             target: runtime-env
             base_image: ubuntu:focal
             base_runtime_image: ubuntu:focal
-            voicevox_core_version: 0.6.0
-            voicevox_core_example_version: 0.6.0
             voicevox_core_library_name: core_cpu
             libtorch_url: https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcpu.zip
           - os: ubuntu-latest
@@ -32,8 +32,6 @@ jobs:
             target: runtime-env
             base_image: ubuntu:focal
             base_runtime_image: ubuntu:focal
-            voicevox_core_version: 0.6.0
-            voicevox_core_example_version: 0.6.0
             voicevox_core_library_name: core_cpu
             libtorch_url: https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcpu.zip
           - os: ubuntu-latest
@@ -41,8 +39,6 @@ jobs:
             target: runtime-env
             base_image: ubuntu:focal
             base_runtime_image: ubuntu:focal
-            voicevox_core_version: 0.6.0
-            voicevox_core_example_version: 0.6.0
             voicevox_core_library_name: core_cpu
             libtorch_url: https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcpu.zip
           - os: ubuntu-latest
@@ -50,8 +46,6 @@ jobs:
             target: runtime-nvidia-env
             base_image: ubuntu:focal
             base_runtime_image: nvidia/cuda:11.4.1-cudnn8-runtime-ubuntu20.04
-            voicevox_core_version: 0.6.0
-            voicevox_core_example_version: 0.6.0
             voicevox_core_library_name: core
             libtorch_url: https://download.pytorch.org/libtorch/cu111/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcu111.zip
           - os: ubuntu-latest
@@ -59,8 +53,6 @@ jobs:
             target: runtime-nvidia-env
             base_image: ubuntu:focal
             base_runtime_image: nvidia/cuda:11.4.1-cudnn8-runtime-ubuntu20.04
-            voicevox_core_version: 0.6.0
-            voicevox_core_example_version: 0.6.0
             voicevox_core_library_name: core
             libtorch_url: https://download.pytorch.org/libtorch/cu111/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcu111.zip
 

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -81,8 +81,8 @@ jobs:
             BASE_IMAGE=${{ matrix.base_image }}
             BASE_RUNTIME_IMAGE=${{ matrix.base_runtime_image }}
             VOICEVOX_CORE_VERSION=${{ matrix.voicevox_core_version }}
-            VOICEVOX_CORE_EXAMPLE_VERSION=${{ matrix.voicevox_core_example_version }}
             VOICEVOX_CORE_LIBRARY_NAME=${{ matrix.voicevox_core_library_name }}
+            VOICEVOX_CORE_EXAMPLE_VERSION=${{ matrix.voicevox_core_example_version }}
             LIBTORCH_URL=${{ matrix.libtorch_url }}
           target: ${{ matrix.target }}
           push: true

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -19,8 +19,8 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         base_image: [ubuntu:focal]
-        voicevox_core_version: [0.5.2]
-        voicevox_core_example_version: [0.5.2]
+        voicevox_core_version: [0.6.0]
+        voicevox_core_example_version: [0.6.0]
         include:
           - tag: ''
             target: runtime-env

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -17,6 +17,7 @@ jobs:
 
     strategy:
       matrix:
+        os: [ubuntu-latest]
         tag:
           - ''
           - cpu
@@ -26,36 +27,31 @@ jobs:
         voicevox_core_version: [0.6.0]
         voicevox_core_example_version: [0.6.0]
         include:
-          - os: ubuntu-latest
-            tag: ''
+          - tag: ''
             target: runtime-env
             base_image: ubuntu:focal
             base_runtime_image: ubuntu:focal
             voicevox_core_library_name: core_cpu
             libtorch_url: https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcpu.zip
-          - os: ubuntu-latest
-            tag: cpu
+          - tag: cpu
             target: runtime-env
             base_image: ubuntu:focal
             base_runtime_image: ubuntu:focal
             voicevox_core_library_name: core_cpu
             libtorch_url: https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcpu.zip
-          - os: ubuntu-latest
-            tag: cpu-ubuntu20.04
+          - tag: cpu-ubuntu20.04
             target: runtime-env
             base_image: ubuntu:focal
             base_runtime_image: ubuntu:focal
             voicevox_core_library_name: core_cpu
             libtorch_url: https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcpu.zip
-          - os: ubuntu-latest
-            tag: nvidia
+          - tag: nvidia
             target: runtime-nvidia-env
             base_image: ubuntu:focal
             base_runtime_image: nvidia/cuda:11.4.1-cudnn8-runtime-ubuntu20.04
             voicevox_core_library_name: core
             libtorch_url: https://download.pytorch.org/libtorch/cu111/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcu111.zip
-          - os: ubuntu-latest
-            tag: nvidia-ubuntu20.04
+          - tag: nvidia-ubuntu20.04
             target: runtime-nvidia-env
             base_image: ubuntu:focal
             base_runtime_image: nvidia/cuda:11.4.1-cudnn8-runtime-ubuntu20.04

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -17,6 +17,7 @@ jobs:
 
     strategy:
       matrix:
+        os: [ubuntu-latest]
         voicevox_core_version: [0.6.0]
         voicevox_core_example_version: [0.6.0]
         include:

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -17,39 +17,33 @@ jobs:
 
     strategy:
       matrix:
+        os: [ubuntu-latest]
+        base_image: [ubuntu:focal]
+        voicevox_core_version: [0.5.2]
+        voicevox_core_example_version: [0.5.2]
         include:
-          - os: ubuntu-latest
-            tag: ''
+          - tag: ''
             target: runtime-env
-            base_image: ubuntu:focal
             base_runtime_image: ubuntu:focal
             inference_device: cpu
             libtorch_url: https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcpu.zip
-          - os: ubuntu-latest
-            tag: cpu
+          - tag: cpu
             target: runtime-env
-            base_image: ubuntu:focal
             base_runtime_image: ubuntu:focal
             inference_device: cpu
             libtorch_url: https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcpu.zip
-          - os: ubuntu-latest
-            tag: cpu-ubuntu20.04
+          - tag: cpu-ubuntu20.04
             target: runtime-env
-            base_image: ubuntu:focal
             base_runtime_image: ubuntu:focal
             inference_device: cpu
             libtorch_url: https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcpu.zip
-          - os: ubuntu-latest
-            tag: nvidia
+          - tag: nvidia
             target: runtime-nvidia-env
-            base_image: ubuntu:focal
             base_runtime_image: nvidia/cuda:11.4.1-cudnn8-runtime-ubuntu20.04
             inference_device: nvidia
             libtorch_url: https://download.pytorch.org/libtorch/cu111/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcu111.zip
-          - os: ubuntu-latest
-            tag: nvidia-ubuntu20.04
+          - tag: nvidia-ubuntu20.04
             target: runtime-nvidia-env
-            base_image: ubuntu:focal
             base_runtime_image: nvidia/cuda:11.4.1-cudnn8-runtime-ubuntu20.04
             inference_device: nvidia
             libtorch_url: https://download.pytorch.org/libtorch/cu111/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcu111.zip
@@ -86,6 +80,8 @@ jobs:
           build-args: |
             BASE_IMAGE=${{ matrix.base_image }}
             BASE_RUNTIME_IMAGE=${{ matrix.base_runtime_image }}
+            VOICEVOX_CORE_VERSION=${{ matrix.voicevox_core_version }}
+            VOICEVOX_CORE_EXAMPLE_VERSION=${{ matrix.voicevox_core_example_version }}
             INFERENCE_DEVICE=${{ matrix.inference_device }}
             LIBTORCH_URL=${{ matrix.libtorch_url }}
           target: ${{ matrix.target }}

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -18,8 +18,7 @@ jobs:
     strategy:
       matrix:
         include:
-          -
-            os: ubuntu-latest
+          - os: ubuntu-latest
             tag: ''
             target: runtime-env
             base_image: ubuntu:focal
@@ -28,8 +27,7 @@ jobs:
             voicevox_core_example_version: 0.6.0
             voicevox_core_library_name: core_cpu
             libtorch_url: https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcpu.zip
-          -
-            os: ubuntu-latest
+          - os: ubuntu-latest
             tag: cpu
             target: runtime-env
             base_image: ubuntu:focal
@@ -38,8 +36,7 @@ jobs:
             voicevox_core_example_version: 0.6.0
             voicevox_core_library_name: core_cpu
             libtorch_url: https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcpu.zip
-          -
-            os: ubuntu-latest
+          - os: ubuntu-latest
             tag: cpu-ubuntu20.04
             target: runtime-env
             base_image: ubuntu:focal
@@ -48,8 +45,7 @@ jobs:
             voicevox_core_example_version: 0.6.0
             voicevox_core_library_name: core_cpu
             libtorch_url: https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcpu.zip
-          -
-            os: ubuntu-latest
+          - os: ubuntu-latest
             tag: nvidia
             target: runtime-nvidia-env
             base_image: ubuntu:focal
@@ -58,8 +54,7 @@ jobs:
             voicevox_core_example_version: 0.6.0
             voicevox_core_library_name: core
             libtorch_url: https://download.pytorch.org/libtorch/cu111/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcu111.zip
-          -
-            os: ubuntu-latest
+          - os: ubuntu-latest
             tag: nvidia-ubuntu20.04
             target: runtime-nvidia-env
             base_image: ubuntu:focal

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -1,8 +1,8 @@
 name: build-docker
 on:
   push:
-    # branches:
-    #   - master
+    branches:
+      - master
   release:
     types:
       - created

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,13 +25,13 @@ jobs:
           target: build-env
           base_runtime_image: ubuntu:focal
           libtorch_url: https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcpu.zip
-          voicevox_core_so_name: libcore_cpu.so
+          voicevox_core_library_name: core_cpu
           nuitka_cache_path: nuitka_cache
         - tag: build-nvidia-ubuntu20.04
           runtime_tag: nvidia-ubuntu20.04 # for cache use
           target: build-env
           base_runtime_image: nvidia/cuda:11.4.1-cudnn8-runtime-ubuntu20.04
-          voicevox_core_so_name: libcore.so
+          voicevox_core_library_name: core
           libtorch_url: https://download.pytorch.org/libtorch/cu111/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcu111.zip
           artifact_name: linux-nvidia
           nuitka_cache_path: nuitka_cache
@@ -67,7 +67,7 @@ jobs:
             BASE_RUNTIME_IMAGE=${{ matrix.base_runtime_image }}
             VOICEVOX_CORE_VERSION=${{ matrix.voicevox_core_version }}
             VOICEVOX_CORE_EXAMPLE_VERSION=${{ matrix.voicevox_core_example_version }}
-            VOICEVOX_CORE_SO_NAME=${{ matrix.voicevox_core_so_name }}
+            VOICEVOX_CORE_LIBRARY_NAME=${{ matrix.voicevox_core_library_name }}
             LIBTORCH_URL=${{ matrix.libtorch_url }}
           target: ${{ matrix.target }}
           load: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,8 +66,8 @@ jobs:
             BASE_IMAGE=${{ matrix.base_image }}
             BASE_RUNTIME_IMAGE=${{ matrix.base_runtime_image }}
             VOICEVOX_CORE_VERSION=${{ matrix.voicevox_core_version }}
-            VOICEVOX_CORE_EXAMPLE_VERSION=${{ matrix.voicevox_core_example_version }}
             VOICEVOX_CORE_LIBRARY_NAME=${{ matrix.voicevox_core_library_name }}
+            VOICEVOX_CORE_EXAMPLE_VERSION=${{ matrix.voicevox_core_example_version }}
             LIBTORCH_URL=${{ matrix.libtorch_url }}
           target: ${{ matrix.target }}
           load: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        base_image: [ubuntu:focal]
+        base_image: ['ubuntu:focal']
         voicevox_core_version: [0.6.0]
         voicevox_core_example_version: [0.6.0]
         include:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,22 +15,27 @@ jobs:
   build-linux:
     strategy:
       matrix:
-        os: [ubuntu-latest]
-        base_image: ['ubuntu:focal']
-        voicevox_core_version: [0.6.0]
-        voicevox_core_example_version: [0.6.0]
         include:
-        - tag: build-cpu-ubuntu20.04
+        - os: ubuntu-latest
+          tag: build-cpu-ubuntu20.04
           runtime_tag: cpu-ubuntu20.04 # for cache use
           target: build-env
+          base_image: ubuntu:focal
           base_runtime_image: ubuntu:focal
-          libtorch_url: https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcpu.zip
+          voicevox_core_version: 0.6.0
+          voicevox_core_example_version: 0.6.0
           voicevox_core_library_name: core_cpu
+          libtorch_url: https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcpu.zip
+          artifact_name: linux-cpu
           nuitka_cache_path: nuitka_cache
-        - tag: build-nvidia-ubuntu20.04
+        - os: ubuntu-latest
+          tag: build-nvidia-ubuntu20.04
           runtime_tag: nvidia-ubuntu20.04 # for cache use
           target: build-env
+          base_image: ubuntu:focal
           base_runtime_image: nvidia/cuda:11.4.1-cudnn8-runtime-ubuntu20.04
+          voicevox_core_version: 0.6.0
+          voicevox_core_example_version: 0.6.0
           voicevox_core_library_name: core
           libtorch_url: https://download.pytorch.org/libtorch/cu111/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcu111.zip
           artifact_name: linux-nvidia

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,8 +22,7 @@ jobs:
         voicevox_core_version: [0.6.0]
         voicevox_core_example_version: [0.6.0]
         include:
-        - os: ubuntu-latest
-          tag: build-cpu-ubuntu20.04
+        - tag: build-cpu-ubuntu20.04
           runtime_tag: cpu-ubuntu20.04 # for cache use
           target: build-env
           base_image: ubuntu:focal
@@ -32,8 +31,7 @@ jobs:
           libtorch_url: https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcpu.zip
           artifact_name: linux-cpu
           nuitka_cache_path: nuitka_cache
-        - os: ubuntu-latest
-          tag: build-nvidia-ubuntu20.04
+        - tag: build-nvidia-ubuntu20.04
           runtime_tag: nvidia-ubuntu20.04 # for cache use
           target: build-env
           base_image: ubuntu:focal

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,22 +15,22 @@ jobs:
   build-linux:
     strategy:
       matrix:
+        os: [ubuntu-latest]
+        base_image: [ubuntu:focal]
+        voicevox_core_version: [0.5.2]
+        voicevox_core_example_version: [0.5.2]
         include:
-        - os: ubuntu-latest
-          tag: build-cpu-ubuntu20.04
+        - tag: build-cpu-ubuntu20.04
           runtime_tag: cpu-ubuntu20.04 # for cache use
           target: build-env
-          base_image: ubuntu:focal
           base_runtime_image: ubuntu:focal
           inference_device: cpu
           libtorch_url: https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcpu.zip
           artifact_name: linux-cpu
           nuitka_cache_path: nuitka_cache
-        - os: ubuntu-latest
-          tag: build-nvidia-ubuntu20.04
+        - tag: build-nvidia-ubuntu20.04
           runtime_tag: nvidia-ubuntu20.04 # for cache use
           target: build-env
-          base_image: ubuntu:focal
           base_runtime_image: nvidia/cuda:11.4.1-cudnn8-runtime-ubuntu20.04
           inference_device: nvidia
           libtorch_url: https://download.pytorch.org/libtorch/cu111/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcu111.zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,22 +17,21 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         base_image: [ubuntu:focal]
-        voicevox_core_version: [0.5.2]
-        voicevox_core_example_version: [0.5.2]
+        voicevox_core_version: [0.6.0]
+        voicevox_core_example_version: [0.6.0]
         include:
         - tag: build-cpu-ubuntu20.04
           runtime_tag: cpu-ubuntu20.04 # for cache use
           target: build-env
           base_runtime_image: ubuntu:focal
-          inference_device: cpu
           libtorch_url: https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcpu.zip
-          artifact_name: linux-cpu
+          voicevox_core_so_name: libcore_cpu.so
           nuitka_cache_path: nuitka_cache
         - tag: build-nvidia-ubuntu20.04
           runtime_tag: nvidia-ubuntu20.04 # for cache use
           target: build-env
           base_runtime_image: nvidia/cuda:11.4.1-cudnn8-runtime-ubuntu20.04
-          inference_device: nvidia
+          voicevox_core_so_name: libcore.so
           libtorch_url: https://download.pytorch.org/libtorch/cu111/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcu111.zip
           artifact_name: linux-nvidia
           nuitka_cache_path: nuitka_cache
@@ -66,7 +65,9 @@ jobs:
           build-args: |
             BASE_IMAGE=${{ matrix.base_image }}
             BASE_RUNTIME_IMAGE=${{ matrix.base_runtime_image }}
-            INFERENCE_DEVICE=${{ matrix.inference_device }}
+            VOICEVOX_CORE_VERSION=${{ matrix.voicevox_core_version }}
+            VOICEVOX_CORE_EXAMPLE_VERSION=${{ matrix.voicevox_core_example_version }}
+            VOICEVOX_CORE_SO_NAME=${{ matrix.voicevox_core_so_name }}
             LIBTORCH_URL=${{ matrix.libtorch_url }}
           target: ${{ matrix.target }}
           load: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,12 @@ jobs:
   build-linux:
     strategy:
       matrix:
+        os: [ubuntu-latest]
+        tag:
+          - build-cpu-ubuntu20.04
+          - build-nvidia-ubuntu20.04
+        voicevox_core_version: [0.6.0]
+        voicevox_core_example_version: [0.6.0]
         include:
         - os: ubuntu-latest
           tag: build-cpu-ubuntu20.04
@@ -22,8 +28,6 @@ jobs:
           target: build-env
           base_image: ubuntu:focal
           base_runtime_image: ubuntu:focal
-          voicevox_core_version: 0.6.0
-          voicevox_core_example_version: 0.6.0
           voicevox_core_library_name: core_cpu
           libtorch_url: https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcpu.zip
           artifact_name: linux-cpu
@@ -34,8 +38,6 @@ jobs:
           target: build-env
           base_image: ubuntu:focal
           base_runtime_image: nvidia/cuda:11.4.1-cudnn8-runtime-ubuntu20.04
-          voicevox_core_version: 0.6.0
-          voicevox_core_example_version: 0.6.0
           voicevox_core_library_name: core
           libtorch_url: https://download.pytorch.org/libtorch/cu111/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcu111.zip
           artifact_name: linux-nvidia

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,8 +66,8 @@ jobs:
             BASE_IMAGE=${{ matrix.base_image }}
             BASE_RUNTIME_IMAGE=${{ matrix.base_runtime_image }}
             VOICEVOX_CORE_VERSION=${{ matrix.voicevox_core_version }}
-            VOICEVOX_CORE_LIBRARY_NAME=${{ matrix.voicevox_core_library_name }}
             VOICEVOX_CORE_EXAMPLE_VERSION=${{ matrix.voicevox_core_example_version }}
+            VOICEVOX_CORE_LIBRARY_NAME=${{ matrix.voicevox_core_library_name }}
             LIBTORCH_URL=${{ matrix.libtorch_url }}
           target: ${{ matrix.target }}
           load: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,15 +33,6 @@ RUN <<EOF
     ldconfig
 EOF
 
-# Workaround: overwrite libcore.so with libcore_cpu.so for cpu image
-ARG VOICEVOX_CORE_SO_NAME=cpu
-RUN <<EOF
-    cd /opt/voicevox_core/
-    if [ "${VOICEVOX_CORE_SO_NAME}" != "libcore.so" ]; then
-      mv "${VOICEVOX_CORE_SO_NAME}" "libcore.so"
-    fi
-EOF
-
 
 # Download LibTorch
 FROM ${BASE_IMAGE} AS download-libtorch-env
@@ -171,6 +162,14 @@ RUN <<EOF
     git clone -b "${VOICEVOX_CORE_EXAMPLE_VERSION}" --depth 1 https://github.com/Hiroshiba/voicevox_core.git /opt/voicevox_core_example
     cd /opt/voicevox_core_example/
     cp ./core.h ./example/python/
+EOF
+
+
+# Workaround: overwrite libcore.so with libcore_cpu.so for cpu image
+ARG VOICEVOX_CORE_LIBRARY_NAME=core_cpu
+RUN <<EOF
+  set -eux
+  sed -i 's/libraries=\["core"\]/libraries=["'${VOICEVOX_CORE_LIBRARY_NAME}'"]/' /opt/voicevox_core_example/example/python/setup.py
 EOF
 
 # Add local files

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN <<EOF
     # Prevent error: `/sbin/ldconfig.real: /opt/voicevox_core/libcore.so is not a symbolic link`
     set -eux
     if [ "${VOICEVOX_CORE_LIBRARY_NAME}" = "core" ]; then
-        rm /opt/voicevox_core/libcore_cpu.so
+        rm -f /opt/voicevox_core/libcore_cpu.so
     elif [ "${VOICEVOX_CORE_LIBRARY_NAME}" = "core_cpu" ]; then
         mv /opt/voicevox_core/libcore_cpu.so /opt/voicevox_core/libcore.so
     else

--- a/Dockerfile
+++ b/Dockerfile
@@ -180,7 +180,7 @@ COPY --from=download-core-env /opt/voicevox_core /opt/voicevox_core
 COPY --from=download-libtorch-env /etc/ld.so.conf.d/libtorch.conf /etc/ld.so.conf.d/libtorch.conf
 COPY --from=download-libtorch-env /opt/libtorch /opt/libtorch
 
-# Clone voicevox_core
+# Clone VOICEVOX Core example
 ARG VOICEVOX_CORE_EXAMPLE_VERSION=0.5.2
 RUN <<EOF
     git clone -b "${VOICEVOX_CORE_EXAMPLE_VERSION}" --depth 1 https://github.com/Hiroshiba/voicevox_core.git /opt/voicevox_core_example

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN <<EOF
     rm -rf /var/lib/apt/lists/*
 EOF
 
-ARG VOICEVOX_CORE_VERSION=0.5.2
+ARG VOICEVOX_CORE_VERSION=0.6.0
 RUN <<EOF
     wget -nv --show-progress -c -O "./core.zip" "https://github.com/Hiroshiba/voicevox_core/releases/download/${VOICEVOX_CORE_VERSION}/core.zip"
     unzip "./core.zip"
@@ -181,7 +181,7 @@ COPY --from=download-libtorch-env /etc/ld.so.conf.d/libtorch.conf /etc/ld.so.con
 COPY --from=download-libtorch-env /opt/libtorch /opt/libtorch
 
 # Clone VOICEVOX Core example
-ARG VOICEVOX_CORE_EXAMPLE_VERSION=0.5.2
+ARG VOICEVOX_CORE_EXAMPLE_VERSION=0.6.0
 RUN <<EOF
     git clone -b "${VOICEVOX_CORE_EXAMPLE_VERSION}" --depth 1 https://github.com/Hiroshiba/voicevox_core.git /opt/voicevox_core_example
     cd /opt/voicevox_core_example/

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ RUN <<EOF
     if [ "${VOICEVOX_CORE_LIBRARY_NAME}" = "core" ]; then
         rm /opt/voicevox_core/libcore_cpu.so
     elif [ "${VOICEVOX_CORE_LIBRARY_NAME}" = "core_cpu" ]; then
-        rm /opt/voicevox_core/libcore.so
+        mv /opt/voicevox_core/libcore_cpu.so /opt/voicevox_core/libcore.so
     else
         echo "Invalid VOICEVOX CORE library name: ${VOICEVOX_CORE_LIBRARY_NAME}" >> /dev/stderr
         exit 1
@@ -177,13 +177,6 @@ RUN <<EOF
     git clone -b "${VOICEVOX_CORE_EXAMPLE_VERSION}" --depth 1 https://github.com/Hiroshiba/voicevox_core.git /opt/voicevox_core_example
     cd /opt/voicevox_core_example/
     cp ./core.h ./example/python/
-EOF
-
-# Workaround: replace shared object name in setup.py
-ARG VOICEVOX_CORE_LIBRARY_NAME=core_cpu
-RUN <<EOF
-  set -eux
-  sed -i 's/libraries=\["core"\]/libraries=["'${VOICEVOX_CORE_LIBRARY_NAME}'"]/' /opt/voicevox_core_example/example/python/setup.py
 EOF
 
 # Add local files

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,9 @@ RUN <<EOF
     unzip "./core.zip"
     mv ./core /opt/voicevox_core
     rm ./core.zip
+EOF
 
+RUN <<EOF
     # Workaround: remove unused libcore (cpu, gpu)
     # Prevent error: `/sbin/ldconfig.real: /opt/voicevox_core/libcore.so is not a symbolic link`
     set -eux

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ build-linux-docker-ubuntu:
 		--build-arg BASE_IMAGE=ubuntu:focal \
 		--build-arg BASE_RUNTIME_IMAGE=ubuntu:focal \
 		--build-arg LIBTORCH_URL=https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcpu.zip \
-		--build-arg VOICEVOX_CORE_SO_NAME=libcore_cpu.so
+		--build-arg VOICEVOX_CORE_LIBRARY_NAME=core_cpu
 
 .PHONY: run-linux-docker-ubuntu
 run-linux-docker-ubuntu:
@@ -26,7 +26,7 @@ build-linux-docker-nvidia:
 		--build-arg BASE_IMAGE=ubuntu:focal \
 		--build-arg BASE_RUNTIME_IMAGE=nvidia/cuda:11.4.1-cudnn8-runtime-ubuntu20.04 \
 		--build-arg LIBTORCH_URL=https://download.pytorch.org/libtorch/cu111/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcu111.zip \
-		--build-arg VOICEVOX_CORE_SO_NAME=libcore.so
+		--build-arg VOICEVOX_CORE_LIBRARY_NAME=core
 
 .PHONY: run-linux-docker-nvidia
 run-linux-docker-nvidia:
@@ -58,7 +58,7 @@ build-linux-docker-build:
 		--build-arg BASE_IMAGE=ubuntu:focal \
 		--build-arg BASE_RUNTIME_IMAGE=ubuntu:focal \
 		--build-arg LIBTORCH_URL=https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcpu.zip \
-		--build-arg VOICEVOX_CORE_SO_NAME=libcore_cpu.so
+		--build-arg VOICEVOX_CORE_LIBRARY_NAME=core_cpu
 
 .PHONY: run-linux-docker-build
 run-linux-docker-build:
@@ -77,7 +77,7 @@ build-linux-docker-build-nvidia:
 		--build-arg BASE_IMAGE=ubuntu:focal \
 		--build-arg BASE_RUNTIME_IMAGE=nvidia/cuda:11.4.1-cudnn8-runtime-ubuntu20.04 \
 		--build-arg LIBTORCH_URL=https://download.pytorch.org/libtorch/cu111/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcu111.zip \
-		--build-arg VOICEVOX_CORE_SO_NAME=libcore.so
+		--build-arg VOICEVOX_CORE_LIBRARY_NAME=core
 
 .PHONY: run-linux-docker-build-nvidia
 run-linux-docker-build-nvidia:

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ build-linux-docker-ubuntu:
 		--build-arg BASE_IMAGE=ubuntu:focal \
 		--build-arg BASE_RUNTIME_IMAGE=ubuntu:focal \
 		--build-arg LIBTORCH_URL=https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcpu.zip \
-		--build-arg INFERENCE_DEVICE=cpu
+		--build-arg VOICEVOX_CORE_SO_NAME=libcore_cpu.so
 
 .PHONY: run-linux-docker-ubuntu
 run-linux-docker-ubuntu:
@@ -26,7 +26,7 @@ build-linux-docker-nvidia:
 		--build-arg BASE_IMAGE=ubuntu:focal \
 		--build-arg BASE_RUNTIME_IMAGE=nvidia/cuda:11.4.1-cudnn8-runtime-ubuntu20.04 \
 		--build-arg LIBTORCH_URL=https://download.pytorch.org/libtorch/cu111/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcu111.zip \
-		--build-arg INFERENCE_DEVICE=nvidia
+		--build-arg VOICEVOX_CORE_SO_NAME=libcore.so
 
 .PHONY: run-linux-docker-nvidia
 run-linux-docker-nvidia:
@@ -58,7 +58,7 @@ build-linux-docker-build:
 		--build-arg BASE_IMAGE=ubuntu:focal \
 		--build-arg BASE_RUNTIME_IMAGE=ubuntu:focal \
 		--build-arg LIBTORCH_URL=https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcpu.zip \
-		--build-arg INFERENCE_DEVICE=cpu
+		--build-arg VOICEVOX_CORE_SO_NAME=libcore_cpu.so
 
 .PHONY: run-linux-docker-build
 run-linux-docker-build:
@@ -77,7 +77,7 @@ build-linux-docker-build-nvidia:
 		--build-arg BASE_IMAGE=ubuntu:focal \
 		--build-arg BASE_RUNTIME_IMAGE=nvidia/cuda:11.4.1-cudnn8-runtime-ubuntu20.04 \
 		--build-arg LIBTORCH_URL=https://download.pytorch.org/libtorch/cu111/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcu111.zip \
-		--build-arg INFERENCE_DEVICE=nvidia
+		--build-arg VOICEVOX_CORE_SO_NAME=libcore.so
 
 .PHONY: run-linux-docker-build-nvidia
 run-linux-docker-build-nvidia:


### PR DESCRIPTION
- [x] Jobの変数・Dockerのbuild-argを変更
    - [x] `INFERENCE_DEVICE`を廃止（複数の目的に使われないようにするため）
    - [x] `VOICEVOX_CORE_LIBRARY_NAME`を追加（`core_cpu`または`core`）
- [x] VOICEVOX CORE 0.6.0に追従
    - CPU版イメージでは、CPU版共有ライブラリ（`libcore_cpu.so`）を使用

## `VOICEVOX_CORE_LIBRARY_NAME`
- CPU・GPUどちらの共有ライブラリ（`libcore_cpu.so`、`libcore.so`）を使うか選択
- イメージ内では、VOICEVOX COREの共有ライブラリ名を`libcore.so`に統一
    - `ldconfig` がCPU・GPUの共有ライブラリを重複したライブラリとして扱い、一方を認識しない問題が起きたため
    - エラー内容: `/sbin/ldconfig.real: /opt/voicevox_core/libcore.so is not a symbolic link`
