### PR TITLE
Release作成時、自動ビルドの成果物をAssetsとして自動アップロード

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -372,3 +372,47 @@ jobs:
           name: ${{ matrix.artifact_name }}
           path: |
             artifact/
+
+
+  upload-to-release:
+    if: github.event.release.tag_name != ''
+    needs: [build-linux, build-windows]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        artifact_name:
+          - linux-cpu
+          - linux-nvidia
+          - windows-cpu
+          - windows-nvidia
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+              p7zip-full
+
+      - name: Download and extract artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: ${{ matrix.artifact_name }}
+          path: ${{ matrix.artifact_name }}/
+
+      - name: Rearchive and split artifact
+        run: |
+          # compressed to artifact.7z.001, artifact.7z.002, ...
+          7z -r -v1g a "${{ matrix.artifact_name }}.7z" "${{ matrix.artifact_name }}/"
+
+          # Output splitted archive list
+          ls ${{ matrix.artifact_name }}.7z.* > archives.txt
+          mv archives.txt "${{ matrix.artifact_name }}.7z.txt"
+
+      - name: Upload splitted archives to Release assets
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ github.ref }} # == github.event.release.tag_name
+          file_glob: true
+          file: ${{ matrix.artifact_name }}.7z.*


### PR DESCRIPTION
GitHub Release作成時、自動ビルドの成果物（Artifact）をReleaseのAssetsとして自動アップロードします。

Artifactが保持期限を過ぎると自動削除されるため、VOICEVOXの自動ビルドなどのために、安定的な実行バイナリのダウンロードリンクを提供できない問題を解決します。

Assetsへのアップロードでは、サイズ制限（2GB）を回避するため、1GBごとに分割した7zファイルをアップロードします。

利便性のため、分割ファイルリストをテキストファイルとして、合わせてアップロードします。
このPRでは、VOICEVOXの分割形式（ini）と互換性はありません。
また、ファイルサイズやハッシュ値の添付もしていません。

- Workflowの実行例: https://github.com/aoirint/voicevox_engine/actions/runs/1269908655
- Releaseの例: https://github.com/aoirint/voicevox_engine/releases/tag/0.5.2-aoirint-57

Assetsへのアップロードは、GitHub Actionsの14GBの容量制限を回避するため、ビルドとは別のJobとして実行しています。

すべてのArtifactが作成されるまで、つまりすべてのbuild-linux、build-windowsが正常に終了するまで、Assetsへのアップロードが開始されない問題があります。
