### PR TITLE
Linux GPU用Dockerイメージのベースイメージをnvidia/driverに変更

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -51,13 +51,13 @@ jobs:
           - tag: nvidia
             target: runtime-nvidia-env
             base_image: ubuntu:focal
-            base_runtime_image: ubuntu:focal
+            base_runtime_image: nvidia/driver:460.73.01-ubuntu20.04
             voicevox_core_library_name: core
             libtorch_url: https://download.pytorch.org/libtorch/cu111/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcu111.zip
           - tag: nvidia-ubuntu20.04
             target: runtime-nvidia-env
             base_image: ubuntu:focal
-            base_runtime_image: ubuntu:focal
+            base_runtime_image: nvidia/driver:460.73.01-ubuntu20.04
             voicevox_core_library_name: core
             libtorch_url: https://download.pytorch.org/libtorch/cu111/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcu111.zip
           # Ubuntu 18.04
@@ -71,7 +71,7 @@ jobs:
           - tag: nvidia-ubuntu18.04
             target: runtime-nvidia-env
             base_image: ubuntu:bionic
-            base_runtime_image: ubuntu:bionic
+            base_runtime_image: nvidia/driver:460.73.01-ubuntu18.04
             voicevox_core_library_name: core
             libtorch_url: https://download.pytorch.org/libtorch/cu111/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcu111.zip
             use_glibc_231_workaround: 1

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -51,13 +51,13 @@ jobs:
           - tag: nvidia
             target: runtime-nvidia-env
             base_image: ubuntu:focal
-            base_runtime_image: nvidia/cuda:11.4.1-cudnn8-runtime-ubuntu20.04
+            base_runtime_image: ubuntu:focal
             voicevox_core_library_name: core
             libtorch_url: https://download.pytorch.org/libtorch/cu111/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcu111.zip
           - tag: nvidia-ubuntu20.04
             target: runtime-nvidia-env
             base_image: ubuntu:focal
-            base_runtime_image: nvidia/cuda:11.4.1-cudnn8-runtime-ubuntu20.04
+            base_runtime_image: ubuntu:focal
             voicevox_core_library_name: core
             libtorch_url: https://download.pytorch.org/libtorch/cu111/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcu111.zip
           # Ubuntu 18.04
@@ -71,7 +71,7 @@ jobs:
           - tag: nvidia-ubuntu18.04
             target: runtime-nvidia-env
             base_image: ubuntu:bionic
-            base_runtime_image: nvidia/cuda:11.4.1-cudnn8-runtime-ubuntu18.04
+            base_runtime_image: ubuntu:bionic
             voicevox_core_library_name: core
             libtorch_url: https://download.pytorch.org/libtorch/cu111/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcu111.zip
             use_glibc_231_workaround: 1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
           runtime_tag: nvidia-ubuntu18.04 # for cache use
           target: build-env
           base_image: ubuntu:bionic
-          base_runtime_image: nvidia/cuda:11.4.1-cudnn8-runtime-ubuntu18.04
+          base_runtime_image: ubuntu:bionic
           voicevox_core_library_name: core
           libtorch_url: https://download.pytorch.org/libtorch/cu111/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcu111.zip
           use_glibc_231_workaround: 1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
           runtime_tag: nvidia-ubuntu18.04 # for cache use
           target: build-env
           base_image: ubuntu:bionic
-          base_runtime_image: ubuntu:bionic
+          base_runtime_image: nvidia/driver:460.73.01-ubuntu18.04
           voicevox_core_library_name: core
           libtorch_url: https://download.pytorch.org/libtorch/cu111/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcu111.zip
           use_glibc_231_workaround: 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -72,8 +72,19 @@ RUN <<EOF
     rm ./libtorch.zip
 EOF
 
+ARG USE_GLIBC_231_WORKAROUND=0
 RUN <<EOF
-    echo "/opt/libtorch/lib" > /etc/ld.so.conf.d/libtorch.conf
+    set -eux
+
+    LIBTORCH_PATH="/opt/libtorch/lib"
+
+    # prevent nuitka build error caused by corrupted `ldconfig -p` outputs
+    if [ "${USE_GLIBC_231_WORKAROUND}" = "1" ]; then
+      LIBTORCH_PATH=""
+    fi
+
+    echo "${LIBTORCH_PATH}" > /etc/ld.so.conf.d/libtorch.conf
+
     rm -f /etc/ld.so.cache
     ldconfig
 EOF
@@ -184,15 +195,9 @@ ADD ./requirements.txt /tmp/
 ADD ./voicevox_engine /opt/voicevox_engine/voicevox_engine
 ADD ./run.py ./check_tts.py ./VERSION.txt ./LICENSE ./LGPL_LICENSE /opt/voicevox_engine/
 
-ARG USE_GLIBC_231_WORKAROUND=0
 RUN <<EOF
     # Create a general user
     useradd --create-home user
-
-    # prevent nuitka build error caused by corrupted `ldconfig -p` outputs
-    if [ "${USE_GLIBC_231_WORKAROUND}" = "1" ]; then
-        rm -f /etc/ld.so.conf.d/libtorch.conf
-    fi
 
     # Update ld
     ldconfig
@@ -231,6 +236,7 @@ RUN <<EOF
 EOF
 
 # Create container start shell
+ARG USE_GLIBC_231_WORKAROUND=0
 COPY --chmod=775 <<EOF /entrypoint.sh
 #!/bin/bash
 cat /opt/voicevox_core/README.txt > /dev/stderr

--- a/Dockerfile
+++ b/Dockerfile
@@ -87,6 +87,22 @@ RUN <<EOF
 
     rm -f /etc/ld.so.cache
     ldconfig
+
+    # create soname symbolic link manually instead of ldconfig
+    if [ "${USE_GLIBC_231_WORKAROUND}" = "1" ]; then
+      # FIXME: use build-arg
+      # libnvrtc-builtins-07fb3db5.so.11.1 => libnvrtc-builtins.so.11.1
+
+      # use relative path for symbolic link
+      cd /opt/libtorch/lib
+
+      ln -sf $(find . -name 'libnvrtc-*' -not -name 'libnvrtc-builtins*') ./libnvrtc.so.11.1
+      ln -sf ./libnvrtc-builtins-*.so.11.1 ./libnvrtc-builtins.so.11.1
+      ln -sf ./libnvToolsExt-*.so.1 ./libnvToolsExt.so.1
+      ln -sf ./libcudart-*.so.11.0 ./libcudart.so.11.0
+
+      cd -
+    fi
 EOF
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -96,10 +96,14 @@ RUN <<EOF
       # use relative path for symbolic link
       cd /opt/libtorch/lib
 
-      ln -sf $(find . -name 'libnvrtc-*' -not -name 'libnvrtc-builtins*') ./libnvrtc.so.11.1
-      ln -sf ./libnvrtc-builtins-*.so.11.1 ./libnvrtc-builtins.so.11.1
-      ln -sf ./libnvToolsExt-*.so.1 ./libnvToolsExt.so.1
-      ln -sf ./libcudart-*.so.11.0 ./libcudart.so.11.0
+      # FIXME: consider 2 files existing for each pattern
+      # if LibTorch with CUDA
+      if [ -f ./libcudart-*.so.11.0 ]; then
+        ln -sf ./libcudart-*.so.11.0 ./libcudart.so.11.0
+        ln -sf ./libnvToolsExt-*.so.1 ./libnvToolsExt.so.1
+        ln -sf $(find . -name 'libnvrtc-*' -not -name 'libnvrtc-builtins*') ./libnvrtc.so.11.1
+        ln -sf ./libnvrtc-builtins-*.so.11.1 ./libnvrtc-builtins.so.11.1
+      fi
 
       cd -
     fi

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ build-linux-docker-nvidia-ubuntu20.04:
 		--target runtime-nvidia-env \
 		--progress plain \
 		--build-arg BASE_IMAGE=ubuntu:focal \
-		--build-arg BASE_RUNTIME_IMAGE=nvidia/cuda:11.4.1-cudnn8-runtime-ubuntu20.04 \
+		--build-arg BASE_RUNTIME_IMAGE=ubuntu:focal \
 		--build-arg LIBTORCH_URL=https://download.pytorch.org/libtorch/cu111/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcu111.zip \
 		--build-arg VOICEVOX_CORE_LIBRARY_NAME=core
 
@@ -63,7 +63,7 @@ build-linux-docker-nvidia-ubuntu18.04:
 		--target runtime-nvidia-env \
 		--progress plain \
 		--build-arg BASE_IMAGE=ubuntu:bionic \
-		--build-arg BASE_RUNTIME_IMAGE=nvidia/cuda:11.4.1-cudnn8-runtime-ubuntu18.04 \
+		--build-arg BASE_RUNTIME_IMAGE=ubuntu:bionic \
 		--build-arg LIBTORCH_URL=https://download.pytorch.org/libtorch/cu111/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcu111.zip \
 		--build-arg VOICEVOX_CORE_LIBRARY_NAME=core \
 		--build-arg USE_GLIBC_231_WORKAROUND=1
@@ -147,7 +147,7 @@ build-linux-docker-build-nvidia-ubuntu20.04:
 		--target build-env \
 		--progress plain \
 		--build-arg BASE_IMAGE=ubuntu:focal \
-		--build-arg BASE_RUNTIME_IMAGE=nvidia/cuda:11.4.1-cudnn8-runtime-ubuntu20.04 \
+		--build-arg BASE_RUNTIME_IMAGE=ubuntu:focal \
 		--build-arg LIBTORCH_URL=https://download.pytorch.org/libtorch/cu111/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcu111.zip \
 		--build-arg VOICEVOX_CORE_LIBRARY_NAME=core
 
@@ -184,7 +184,7 @@ build-linux-docker-build-nvidia-ubuntu18.04:
 		--target build-env \
 		--progress plain \
 		--build-arg BASE_IMAGE=ubuntu:bionic \
-		--build-arg BASE_RUNTIME_IMAGE=nvidia/cuda:11.4.1-cudnn8-runtime-ubuntu18.04 \
+		--build-arg BASE_RUNTIME_IMAGE=ubuntu:bionic \
 		--build-arg LIBTORCH_URL=https://download.pytorch.org/libtorch/cu111/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcu111.zip \
 		--build-arg VOICEVOX_CORE_LIBRARY_NAME=core
 

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 CMD=
 NOCACHE=
 
-ARGS=
+ARGS:=
 ifeq ($(NOCACHE),1)
-	ARGS="$(ARGS) --no-cache"
+	ARGS:=$(ARGS) --no-cache
 endif
 
 # Ubuntu 20.04

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,10 @@
 CMD=
+NOCACHE=
+
+ARGS=
+ifeq ($(NOCACHE),1)
+	ARGS="$(ARGS) --no-cache"
+endif
 
 # Ubuntu 20.04
 .PHONY: build-linux-docker-ubuntu20.04
@@ -10,12 +16,12 @@ build-linux-docker-ubuntu20.04:
 		--build-arg BASE_IMAGE=ubuntu:focal \
 		--build-arg BASE_RUNTIME_IMAGE=ubuntu:focal \
 		--build-arg LIBTORCH_URL=https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcpu.zip \
-		--build-arg VOICEVOX_CORE_LIBRARY_NAME=core_cpu
+		--build-arg VOICEVOX_CORE_LIBRARY_NAME=core_cpu $(ARGS)
 
 .PHONY: run-linux-docker-ubuntu20.04
 run-linux-docker-ubuntu20.04:
 	docker run --rm -it \
-		-p '127.0.0.1:50021:50021' \
+		-p '127.0.0.1:50021:50021' $(ARGS) \
 		hiroshiba/voicevox_engine:cpu-ubuntu20.04-latest $(CMD)
 
 .PHONY: build-linux-docker-nvidia-ubuntu20.04
@@ -27,13 +33,13 @@ build-linux-docker-nvidia-ubuntu20.04:
 		--build-arg BASE_IMAGE=ubuntu:focal \
 		--build-arg BASE_RUNTIME_IMAGE=nvidia/driver:460.73.01-ubuntu20.04 \
 		--build-arg LIBTORCH_URL=https://download.pytorch.org/libtorch/cu111/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcu111.zip \
-		--build-arg VOICEVOX_CORE_LIBRARY_NAME=core
+		--build-arg VOICEVOX_CORE_LIBRARY_NAME=core $(ARGS)
 
 .PHONY: run-linux-docker-nvidia-ubuntu20.04
 run-linux-docker-nvidia-ubuntu20.04:
 	docker run --rm -it \
 		--gpus all \
-		-p '127.0.0.1:50021:50021' \
+		-p '127.0.0.1:50021:50021' $(ARGS) \
 		hiroshiba/voicevox_engine:nvidia-ubuntu20.04-latest $(CMD)
 
 
@@ -48,12 +54,12 @@ build-linux-docker-ubuntu18.04:
 		--build-arg BASE_RUNTIME_IMAGE=ubuntu:bionic \
 		--build-arg LIBTORCH_URL=https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcpu.zip \
 		--build-arg VOICEVOX_CORE_LIBRARY_NAME=core_cpu \
-		--build-arg USE_GLIBC_231_WORKAROUND=1
+		--build-arg USE_GLIBC_231_WORKAROUND=1 $(ARGS)
 
 .PHONY: run-linux-docker-ubuntu18.04
 run-linux-docker-ubuntu18.04:
 	docker run --rm -it \
-		-p '127.0.0.1:50021:50021' \
+		-p '127.0.0.1:50021:50021' $(ARGS) \
 		hiroshiba/voicevox_engine:cpu-ubuntu18.04-latest $(CMD)
 
 .PHONY: build-linux-docker-nvidia-ubuntu18.04
@@ -66,13 +72,13 @@ build-linux-docker-nvidia-ubuntu18.04:
 		--build-arg BASE_RUNTIME_IMAGE=nvidia/driver:460.73.01-ubuntu18.04 \
 		--build-arg LIBTORCH_URL=https://download.pytorch.org/libtorch/cu111/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcu111.zip \
 		--build-arg VOICEVOX_CORE_LIBRARY_NAME=core \
-		--build-arg USE_GLIBC_231_WORKAROUND=1
+		--build-arg USE_GLIBC_231_WORKAROUND=1 $(ARGS)
 
 .PHONY: run-linux-docker-nvidia-ubuntu18.04
 run-linux-docker-nvidia-ubuntu18.04:
 	docker run --rm -it \
 		--gpus all \
-		-p '127.0.0.1:50021:50021' \
+		-p '127.0.0.1:50021:50021' $(ARGS) \
 		hiroshiba/voicevox_engine:nvidia-ubuntu18.04-latest $(CMD)
 
 
@@ -83,11 +89,11 @@ build-linux-docker-download-core-env-ubuntu18.04:
 		-t hiroshiba/voicevox_engine:download-core-env-ubuntu18.04 \
 		--target download-core-env \
 		--progress plain \
-		--build-arg BASE_IMAGE=ubuntu:bionic
+		--build-arg BASE_IMAGE=ubuntu:bionic $(ARGS)
 
 .PHONY: run-linux-docker-download-core-env-ubuntu18.04
 run-linux-docker-download-core-env-ubuntu18.04:
-	docker run --rm -it \
+	docker run --rm -it $(ARGS) \
 		hiroshiba/voicevox_engine:download-core-env-ubuntu18.04 $(CMD)
 
 # LibTorch env for test
@@ -97,11 +103,11 @@ build-linux-docker-download-libtorch-env-ubuntu18.04:
 		-t hiroshiba/voicevox_engine:download-libtorch-env-ubuntu18.04 \
 		--target download-libtorch-env \
 		--progress plain \
-		--build-arg BASE_IMAGE=ubuntu:bionic
+		--build-arg BASE_IMAGE=ubuntu:bionic $(ARGS)
 
 .PHONY: run-linux-docker-download-libtorch-env-ubuntu18.04
 run-linux-docker-download-libtorch-env-ubuntu18.04:
-	docker run --rm -it \
+	docker run --rm -it $(ARGS) \
 		hiroshiba/voicevox_engine:download-libtorch-env-ubuntu18.04 $(CMD)
 
 
@@ -112,11 +118,11 @@ build-linux-docker-compile-python-env:
 		-t hiroshiba/voicevox_engine:compile-python-env \
 		--target compile-python-env \
 		--progress plain \
-		--build-arg BASE_IMAGE=ubuntu:focal
+		--build-arg BASE_IMAGE=ubuntu:focal $(ARGS)
 
 .PHONY: run-linux-docker-compile-python-env
 run-linux-docker-compile-python-env:
-	docker run --rm -it \
+	docker run --rm -it $(ARGS) \
 		hiroshiba/voicevox_engine:compile-python-env $(CMD)
 
 
@@ -131,13 +137,13 @@ build-linux-docker-build-ubuntu20.04:
 		--build-arg BASE_IMAGE=ubuntu:focal \
 		--build-arg BASE_RUNTIME_IMAGE=ubuntu:focal \
 		--build-arg LIBTORCH_URL=https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcpu.zip \
-		--build-arg VOICEVOX_CORE_LIBRARY_NAME=core_cpu
+		--build-arg VOICEVOX_CORE_LIBRARY_NAME=core_cpu $(ARGS)
 
 .PHONY: run-linux-docker-build-ubuntu20.04
 run-linux-docker-build-ubuntu20.04:
 	docker run --rm -it \
 		-v "$(shell pwd)/cache/Nuitka:/home/user/.cache/Nuitka" \
-		-v "$(shell pwd)/build:/opt/voicevox_engine_build" \
+		-v "$(shell pwd)/build:/opt/voicevox_engine_build" $(ARGS) \
 		hiroshiba/voicevox_engine:build-cpu-ubuntu20.04-latest $(CMD)
 
 .PHONY: build-linux-docker-build-nvidia-ubuntu20.04
@@ -149,13 +155,13 @@ build-linux-docker-build-nvidia-ubuntu20.04:
 		--build-arg BASE_IMAGE=ubuntu:focal \
 		--build-arg BASE_RUNTIME_IMAGE=nvidia/driver:460.73.01-ubuntu20.04 \
 		--build-arg LIBTORCH_URL=https://download.pytorch.org/libtorch/cu111/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcu111.zip \
-		--build-arg VOICEVOX_CORE_LIBRARY_NAME=core
+		--build-arg VOICEVOX_CORE_LIBRARY_NAME=core $(ARGS)
 
 .PHONY: run-linux-docker-build-nvidia-ubuntu20.04
 run-linux-docker-build-nvidia-ubuntu20.04:
 	docker run --rm -it \
 		-v "$(shell pwd)/cache/Nuitka:/home/user/.cache/Nuitka" \
-		-v "$(shell pwd)/build:/opt/voicevox_engine_build" \
+		-v "$(shell pwd)/build:/opt/voicevox_engine_build" $(ARGS) \
 		hiroshiba/voicevox_engine:build-nvidia-ubuntu20.04-latest $(CMD)
 
 ## Ubuntu 18.04
@@ -169,13 +175,13 @@ build-linux-docker-build-ubuntu18.04:
 		--build-arg BASE_RUNTIME_IMAGE=ubuntu:bionic \
 		--build-arg LIBTORCH_URL=https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcpu.zip \
 		--build-arg VOICEVOX_CORE_LIBRARY_NAME=core_cpu \
-		--build-arg USE_GLIBC_231_WORKAROUND=1
+		--build-arg USE_GLIBC_231_WORKAROUND=1 $(ARGS)
 
 .PHONY: run-linux-docker-build-ubuntu18.04
 run-linux-docker-build-ubuntu18.04:
 	docker run --rm -it \
 		-v "$(shell pwd)/cache/Nuitka:/home/user/.cache/Nuitka" \
-		-v "$(shell pwd)/build:/opt/voicevox_engine_build" \
+		-v "$(shell pwd)/build:/opt/voicevox_engine_build" $(ARGS) \
 		hiroshiba/voicevox_engine:build-cpu-ubuntu18.04-latest $(CMD)
 
 .PHONY: build-linux-docker-build-nvidia-ubuntu18.04
@@ -188,11 +194,11 @@ build-linux-docker-build-nvidia-ubuntu18.04:
 		--build-arg BASE_RUNTIME_IMAGE=nvidia/driver:460.73.01-ubuntu18.04 \
 		--build-arg LIBTORCH_URL=https://download.pytorch.org/libtorch/cu111/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcu111.zip \
 		--build-arg VOICEVOX_CORE_LIBRARY_NAME=core \
-		--build-arg USE_GLIBC_231_WORKAROUND=1
+		--build-arg USE_GLIBC_231_WORKAROUND=1 $(ARGS)
 
 .PHONY: run-linux-docker-build-nvidia-ubuntu18.04
 run-linux-docker-build-nvidia-ubuntu18.04:
 	docker run --rm -it \
 		-v "$(shell pwd)/cache/Nuitka:/home/user/.cache/Nuitka" \
-		-v "$(shell pwd)/build:/opt/voicevox_engine_build" \
+		-v "$(shell pwd)/build:/opt/voicevox_engine_build" $(ARGS) \
 		hiroshiba/voicevox_engine:build-nvidia-ubuntu18.04-latest $(CMD)

--- a/Makefile
+++ b/Makefile
@@ -168,7 +168,8 @@ build-linux-docker-build-ubuntu18.04:
 		--build-arg BASE_IMAGE=ubuntu:bionic \
 		--build-arg BASE_RUNTIME_IMAGE=ubuntu:bionic \
 		--build-arg LIBTORCH_URL=https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcpu.zip \
-		--build-arg VOICEVOX_CORE_LIBRARY_NAME=core_cpu
+		--build-arg VOICEVOX_CORE_LIBRARY_NAME=core_cpu \
+		--build-arg USE_GLIBC_231_WORKAROUND=1
 
 .PHONY: run-linux-docker-build-ubuntu18.04
 run-linux-docker-build-ubuntu18.04:
@@ -186,7 +187,8 @@ build-linux-docker-build-nvidia-ubuntu18.04:
 		--build-arg BASE_IMAGE=ubuntu:bionic \
 		--build-arg BASE_RUNTIME_IMAGE=ubuntu:bionic \
 		--build-arg LIBTORCH_URL=https://download.pytorch.org/libtorch/cu111/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcu111.zip \
-		--build-arg VOICEVOX_CORE_LIBRARY_NAME=core
+		--build-arg VOICEVOX_CORE_LIBRARY_NAME=core \
+		--build-arg USE_GLIBC_231_WORKAROUND=1
 
 .PHONY: run-linux-docker-build-nvidia-ubuntu18.04
 run-linux-docker-build-nvidia-ubuntu18.04:

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ build-linux-docker-nvidia-ubuntu20.04:
 		--target runtime-nvidia-env \
 		--progress plain \
 		--build-arg BASE_IMAGE=ubuntu:focal \
-		--build-arg BASE_RUNTIME_IMAGE=ubuntu:focal \
+		--build-arg BASE_RUNTIME_IMAGE=nvidia/driver:460.73.01-ubuntu20.04 \
 		--build-arg LIBTORCH_URL=https://download.pytorch.org/libtorch/cu111/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcu111.zip \
 		--build-arg VOICEVOX_CORE_LIBRARY_NAME=core
 
@@ -63,7 +63,7 @@ build-linux-docker-nvidia-ubuntu18.04:
 		--target runtime-nvidia-env \
 		--progress plain \
 		--build-arg BASE_IMAGE=ubuntu:bionic \
-		--build-arg BASE_RUNTIME_IMAGE=ubuntu:bionic \
+		--build-arg BASE_RUNTIME_IMAGE=nvidia/driver:460.73.01-ubuntu18.04 \
 		--build-arg LIBTORCH_URL=https://download.pytorch.org/libtorch/cu111/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcu111.zip \
 		--build-arg VOICEVOX_CORE_LIBRARY_NAME=core \
 		--build-arg USE_GLIBC_231_WORKAROUND=1
@@ -147,7 +147,7 @@ build-linux-docker-build-nvidia-ubuntu20.04:
 		--target build-env \
 		--progress plain \
 		--build-arg BASE_IMAGE=ubuntu:focal \
-		--build-arg BASE_RUNTIME_IMAGE=ubuntu:focal \
+		--build-arg BASE_RUNTIME_IMAGE=nvidia/driver:460.73.01-ubuntu20.04 \
 		--build-arg LIBTORCH_URL=https://download.pytorch.org/libtorch/cu111/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcu111.zip \
 		--build-arg VOICEVOX_CORE_LIBRARY_NAME=core
 
@@ -185,7 +185,7 @@ build-linux-docker-build-nvidia-ubuntu18.04:
 		--target build-env \
 		--progress plain \
 		--build-arg BASE_IMAGE=ubuntu:bionic \
-		--build-arg BASE_RUNTIME_IMAGE=ubuntu:bionic \
+		--build-arg BASE_RUNTIME_IMAGE=nvidia/driver:460.73.01-ubuntu18.04 \
 		--build-arg LIBTORCH_URL=https://download.pytorch.org/libtorch/cu111/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcu111.zip \
 		--build-arg VOICEVOX_CORE_LIBRARY_NAME=core \
 		--build-arg USE_GLIBC_231_WORKAROUND=1


### PR DESCRIPTION
## 内容

Linux GPU用Dockerイメージのベースイメージを `nvidia/cuda` から `nvidia/driver` に変更します。

https://github.com/Hiroshiba/voicevox/pull/270 において、
LibTorch同梱のCUDA共有ライブラリが読み込まれない問題が起きました。
挙動は、1回目の音声合成には成功し、2回目の音声合成には失敗するというものでした。
この原因は、CUDA共有ライブラリの参照において、システム側のCUDAが参照されたり、参照されなかったりするということが起きていたのではないかと考えています。

このPRでは、Dockerイメージ内の不要な非同梱CUDA共有ライブラリを除去し、また同梱CUDA共有ライブラリの適切なシンボリックリンクを作成することで、この問題を修正します。

合わせて、runtime-envステージで行っていた、Ubuntu 18.04で
ldconfigがLibTorchの共有ライブラリを取り扱えない問題へのWorkaroundを、
download-libtorchステージに移動します。

- 動作確認
    - [x] nvidia-ubuntu20.04
    - [x] cpu-ubuntu20.04
    - [x] nvidia-ubuntu18.04
    - [x] cpu-ubuntu18.04


## LibTorchとCUDAについて

LibTorchは、LibTorchに同梱されているCUDAの共有ライブラリだけで動作するため、
システム側にCUDAをインストールしておく必要はありませんでした。

以下の4つのLibTorch同梱のCUDA共有ライブラリについて、
Ubuntu 18.04のDockerイメージにおいて、
ファイル名にハッシュ値が付加されていたため、
システム側（/usr/local/cuda*/）のCUDAが使用されていたように思っています。

- libcudart-6d56b25a.so.11.0 (libcudart.so.11.0)
- libnvToolsExt-24de1d56.so.1 (libnvToolsExt.so.1)
- libnvrtc-3a20f2b6.so.11.1 (libnvrtc.so.11.1)
- libnvrtc-builtins-07fb3db5.so.11.1 (libnvrtc-builtins.so.11.1)
    - https://github.com/Hiroshiba/voicevox/pull/270#issuecomment-927357692

これらの共有ライブラリは、本来の名前 (soname)にリネームするか、シンボリックリンクを作成する必要があるようです。

Ubuntu 20.04では、ldconfigがシンボリックリンクを作成していましたが、
Ubuntu 18.04では、LibTorchとの互換性がなくldconfigが実行できないため、
シンボリックリンクが作成されていませんでした。
そのため、自前でシンボリックリンクを作成するようにしています。

## 実行バイナリのサイズについて

実行バイナリには、Artifactの仕様により、シンボリックリンクではなくコピーが含まれるため、容量に若干の無駄ができる問題があります。
Artifactにアップロードする前にtarで固めるなどで対応可能と思いますが、容量制限を気にする必要があり、複雑になりそうなのでこのPRでは対処していません。


## download-libtorchステージへの一部Workaroundの移動について

Ubuntu 18.04のdownload-libtorchは、ldconfigが動作しないことを確認するために
意図的にUSE_GLIBC_231_WORKAROUNDが適用されないようにしていました。

しかし、download-libtorchイメージでldconfigが実行されることで、ldconfigが異常を起こし、壊れた名前のシンボリックリンクが/opt/libtorch/libに作成される問題があるため、このPRで廃止しました。

Workaroundの内容は、`ld.so.conf.d/libtorch.conf` のファイルを削除するものから、
中身を空文字列にするものに変更しています。


## 関連 Issue

ref https://github.com/Hiroshiba/voicevox/pull/270
ref https://github.com/Hiroshiba/voicevox_engine/issues/121#issuecomment-927174004
