### PR TITLE
Windows用実行バイナリ自動ビルドにlicenses.jsonの生成を追加

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -298,6 +298,10 @@ jobs:
 
           pip install .
 
+      - name: Generate licenses.json
+        shell: bash
+        run: python generate_licenses.py > licenses.json
+
       - name: Cache Nuitka (ccache, module-cache)
         uses: actions/cache@v2
         id: nuitka-cache
@@ -327,6 +331,7 @@ jobs:
             --include-package-data=pyopenjtalk
             --include-package-data=resampy
             --include-data-file="VERSION.txt=./"
+            --include-data-file="licenses.json=./"
             --msvc=14.2
             --follow-imports
             --no-prefer-source-code

--- a/README.md
+++ b/README.md
@@ -136,6 +136,8 @@ Build Tools for Visual Studio 2019 が必要です。
 ```bash
 pip install -r requirements-dev.txt
 
+python generate_licenses.py > licenses.json
+
 python -m nuitka \
     --standalone \
     --plugin-enable=numpy \
@@ -145,6 +147,7 @@ python -m nuitka \
     --include-package-data=pyopenjtalk \
     --include-package-data=resampy \
     --include-data-file=VERSION.txt=./ \
+    --include-data-file=licenses.json=./ \
     --include-data-file=C:/path/to/cuda/*.dll=./ \
     --include-data-file=C:/path/to/libtorch/*.dll=./ \
     --include-data-file=C:/音声ライブラリへのパス/*.bin=./ \


### PR DESCRIPTION
## 内容

#125 でWindows用実行バイナリの自動ビルドにlicenses.jsonの生成を追加していなかったので、追加します。

ドキュメントへの追記 https://github.com/Hiroshiba/voicevox_engine/pull/125#issuecomment-929494946 も適用します。

- 確認用Workflow: https://github.com/aoirint/voicevox_engine/actions/runs/1284418312

## 関連 Issue

ref #125
