### PR TITLE
mccabeのライセンスを追加

### DIFF
--- a/generate_licenses.py
+++ b/generate_licenses.py
@@ -109,6 +109,11 @@ def generate_licenses() -> List[License]:
         if license.text == "UNKNOWN":
             if license.name.lower() == "core" and license.version == "0.0.0":
                 continue
+            elif license.name.lower() == "mccabe":
+                with urllib.request.urlopen(
+                    "https://raw.githubusercontent.com/PyCQA/mccabe/master/LICENSE"
+                ) as res:
+                    license.text = res.read().decode()
             elif license.name.lower() == "nuitka":
                 with urllib.request.urlopen(
                     "https://raw.githubusercontent.com/Nuitka/Nuitka/develop/LICENSE.txt"


### PR DESCRIPTION
## 内容
`python generate_licenses.py`でエラーが出たのでその修正です。
自環境では以下のようになっていました。
```json
{
    "License": "MIT License",
    "LicenseText": "UNKNOWN",
    "Name": "mccabe",
    "URL": "https://github.com/pycqa/mccabe",
    "Version": "0.6.1"
}
```

## その他
もしかしたら問題が発生するのは私の環境が悪いのかもしれません...