### PR TITLE
READMEにAPIドキュメントへのリンクを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,10 @@
 
 ## API ドキュメント
 
-VOICEVOX ソフトウェアを起動した状態で、ブラウザから http://localhost:50021/docs にアクセスするとドキュメントが表示されます。  
-[VOICEVOX 音声合成エンジンとの連携](./docs/VOICEVOX音声合成エンジンとの連携.md)も参考になるかもしれません。
+[API ドキュメント](https://hiroshiba.github.io/voicevox_engine/api/)をご参照ください。
+
+VOICEVOX エンジンもしくはエディタを起動した状態で http://localhost:50021/docs にアクセスすると、起動中のエンジンのドキュメントも確認できます。  
+今後の方針などについては [VOICEVOX 音声合成エンジンとの連携](./docs/VOICEVOX音声合成エンジンとの連携.md) も参考になるかもしれません。
 
 リクエスト・レスポンスの文字コードはすべて UTF-8 です。
 
@@ -243,7 +245,7 @@ pysen run format lint
 
 ## APIドキュメントの更新
 
-`docs/api/index.html`の内容を更新します。
+[API ドキュメント](https://hiroshiba.github.io/voicevox_engine/api/)（実体は`docs/api/index.html`）の内容を更新します。
 
 ```bash
 python make_docs.py


### PR DESCRIPTION
## 内容

READMEにAPIドキュメントへのリンクを追加しました。

https://hiroshiba.github.io/voicevox_engine/api/

## 関連 Issue

ref: https://github.com/Hiroshiba/voicevox_engine/pull/186

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他
