### PR TITLE
リファクタリング: PresetLoaderをモジュール化

### DIFF
--- a/run.py
+++ b/run.py
@@ -27,12 +27,11 @@ from voicevox_engine.model import (
     Mora,
     ParseKanaBadRequest,
     ParseKanaError,
-    Preset,
     Speaker,
     SpeakerInfo,
 )
 from voicevox_engine.mora_list import openjtalk_mora2text
-from voicevox_engine.preset import PresetLoader
+from voicevox_engine.preset import Preset, PresetLoader
 from voicevox_engine.synthesis_engine import SynthesisEngine, make_synthesis_engine
 
 

--- a/run.py
+++ b/run.py
@@ -32,8 +32,8 @@ from voicevox_engine.model import (
     SpeakerInfo,
 )
 from voicevox_engine.mora_list import openjtalk_mora2text
-from voicevox_engine.synthesis_engine import SynthesisEngine, make_synthesis_engine
 from voicevox_engine.preset import PresetLoader
+from voicevox_engine.synthesis_engine import SynthesisEngine, make_synthesis_engine
 
 
 def mora_to_text(mora: str):

--- a/test/test_preset.py
+++ b/test/test_preset.py
@@ -1,0 +1,37 @@
+from unittest import TestCase
+
+from pathlib import Path
+from voicevox_engine.preset import PresetLoader
+
+
+class TestPresetLoader(TestCase):
+    def test_validation(self):
+        preset_loader = PresetLoader(preset_path=Path("test/presets-test-1.yaml"))
+        preset_loader.PRESET_FILE_NAME = "test/presets-test-1.yaml"
+        presets, err_detail = preset_loader.load_presets()
+        self.assertFalse(presets is None)
+        self.assertEqual(err_detail, "")
+
+    def test_validation_2(self):
+        preset_loader = PresetLoader(preset_path=Path("test/presets-test-2.yaml"))
+        presets, err_detail = preset_loader.load_presets()
+        self.assertTrue(presets is None)
+        self.assertEqual(err_detail, "プリセットの設定ファイルにミスがあります")
+
+    def test_preset_id(self):
+        preset_loader = PresetLoader(preset_path=Path("test/presets-test-3.yaml"))
+        presets, err_detail = preset_loader.load_presets()
+        self.assertTrue(presets is None)
+        self.assertEqual(err_detail, "プリセットのidに重複があります")
+
+    def test_empty_file(self):
+        preset_loader = PresetLoader(preset_path=Path("test/presets-test-4.yaml"))
+        presets, err_detail = preset_loader.load_presets()
+        self.assertTrue(presets is None)
+        self.assertEqual(err_detail, "プリセットの設定ファイルが空の内容です")
+
+    def test_not_exist_file(self):
+        preset_loader = PresetLoader(preset_path=Path("test/presets-dummy.yaml"))
+        presets, err_detail = preset_loader.load_presets()
+        self.assertTrue(presets is None)
+        self.assertEqual(err_detail, "プリセットの設定ファイルが見つかりません")

--- a/test/test_preset.py
+++ b/test/test_preset.py
@@ -1,6 +1,6 @@
+from pathlib import Path
 from unittest import TestCase
 
-from pathlib import Path
 from voicevox_engine.preset import PresetLoader
 
 

--- a/test/test_run.py
+++ b/test/test_run.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 
-from run import PresetLoader, mora_to_text
+from run import mora_to_text
 
 
 class TestMoraToText(TestCase):
@@ -26,40 +26,3 @@ class TestMoraToText(TestCase):
         """変なモーラが来ても例外を投げない"""
         self.assertEqual(mora_to_text("x"), "x")
         self.assertEqual(mora_to_text(""), "")
-
-
-class TestPresetLoader(TestCase):
-    def test_validation(self):
-        preset_loader = PresetLoader()
-        preset_loader.PRESET_FILE_NAME = "test/presets-test-1.yaml"
-        presets, err_detail = preset_loader.load_presets()
-        self.assertFalse(presets is None)
-        self.assertEqual(err_detail, "")
-
-    def test_validation_2(self):
-        preset_loader = PresetLoader()
-        preset_loader.PRESET_FILE_NAME = "test/presets-test-2.yaml"
-        presets, err_detail = preset_loader.load_presets()
-        self.assertTrue(presets is None)
-        self.assertEqual(err_detail, "プリセットの設定ファイルにミスがあります")
-
-    def test_preset_id(self):
-        preset_loader = PresetLoader()
-        preset_loader.PRESET_FILE_NAME = "test/presets-test-3.yaml"
-        presets, err_detail = preset_loader.load_presets()
-        self.assertTrue(presets is None)
-        self.assertEqual(err_detail, "プリセットのidに重複があります")
-
-    def test_empty_file(self):
-        preset_loader = PresetLoader()
-        preset_loader.PRESET_FILE_NAME = "test/presets-test-4.yaml"
-        presets, err_detail = preset_loader.load_presets()
-        self.assertTrue(presets is None)
-        self.assertEqual(err_detail, "プリセットの設定ファイルが空の内容です")
-
-    def test_not_exist_file(self):
-        preset_loader = PresetLoader()
-        preset_loader.PRESET_FILE_NAME = "test/presets-dummy.yaml"
-        presets, err_detail = preset_loader.load_presets()
-        self.assertTrue(presets is None)
-        self.assertEqual(err_detail, "プリセットの設定ファイルが見つかりません")

--- a/voicevox_engine/model.py
+++ b/voicevox_engine/model.py
@@ -121,23 +121,6 @@ class Speaker(BaseModel):
     version: str = Field("スピーカーのバージョン")
 
 
-class Preset(BaseModel):
-    """
-    プリセット情報
-    """
-
-    id: int = Field(title="プリセットID")
-    name: str = Field(title="プリセット名")
-    speaker_uuid: str = Field(title="スピーカーのUUID")
-    style_id: int = Field(title="スタイルID")
-    speedScale: float = Field(title="全体の話速")
-    pitchScale: float = Field(title="全体の音高")
-    intonationScale: float = Field(title="全体の抑揚")
-    volumeScale: float = Field(title="全体の音量")
-    prePhonemeLength: float = Field(title="音声の前の無音時間")
-    postPhonemeLength: float = Field(title="音声の後の無音時間")
-
-
 class StyleInfo(BaseModel):
     """
     スタイルの追加情報

--- a/voicevox_engine/preset/Preset.py
+++ b/voicevox_engine/preset/Preset.py
@@ -1,0 +1,18 @@
+from pydantic import BaseModel, Field
+
+
+class Preset(BaseModel):
+    """
+    プリセット情報
+    """
+
+    id: int = Field(title="プリセットID")
+    name: str = Field(title="プリセット名")
+    speaker_uuid: str = Field(title="スピーカーのUUID")
+    style_id: int = Field(title="スタイルID")
+    speedScale: float = Field(title="全体の話速")
+    pitchScale: float = Field(title="全体の音高")
+    intonationScale: float = Field(title="全体の抑揚")
+    volumeScale: float = Field(title="全体の音量")
+    prePhonemeLength: float = Field(title="音声の前の無音時間")
+    postPhonemeLength: float = Field(title="音声の後の無音時間")

--- a/voicevox_engine/preset/PresetLoader.py
+++ b/voicevox_engine/preset/PresetLoader.py
@@ -1,6 +1,7 @@
+from pathlib import Path
+
 import yaml
 from pydantic import ValidationError
-from pathlib import Path
 
 from ..model import Preset
 

--- a/voicevox_engine/preset/PresetLoader.py
+++ b/voicevox_engine/preset/PresetLoader.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import yaml
 from pydantic import ValidationError
 
-from ..model import Preset
+from .Preset import Preset
 
 
 class PresetLoader:

--- a/voicevox_engine/preset/PresetLoader.py
+++ b/voicevox_engine/preset/PresetLoader.py
@@ -1,0 +1,58 @@
+import yaml
+from pydantic import ValidationError
+from pathlib import Path
+
+from ..model import Preset
+
+
+class PresetLoader:
+    def __init__(
+        self,
+        preset_path: Path,
+    ):
+        self.presets = []
+        self.last_modified_time = 0
+        self.preset_path = preset_path
+
+    def load_presets(self):
+        """
+        プリセットのYAMLファイルを読み込む
+
+        Returns
+        -------
+        ret: tuple[Preset, str]
+            プリセットとエラー文のタプル
+        """
+        _presets = []
+
+        # 設定ファイルのタイムスタンプを確認
+        try:
+            _last_modified_time = self.preset_path.stat().st_mtime
+            if _last_modified_time == self.last_modified_time:
+                return self.presets, ""
+        except OSError:
+            return None, "プリセットの設定ファイルが見つかりません"
+
+        try:
+            with open(self.preset_path, encoding="utf-8") as f:
+                obj = yaml.safe_load(f)
+                if obj is None:
+                    raise FileNotFoundError
+        except FileNotFoundError:
+            return None, "プリセットの設定ファイルが空の内容です"
+
+        for preset in obj:
+            try:
+                _presets.append(Preset(**preset))
+            except ValidationError:
+                return None, "プリセットの設定ファイルにミスがあります"
+
+        # idが一意か確認
+        if len([preset.id for preset in _presets]) != len(
+            {preset.id for preset in _presets}
+        ):
+            return None, "プリセットのidに重複があります"
+
+        self.presets = _presets
+        self.last_modified_time = _last_modified_time
+        return self.presets, ""

--- a/voicevox_engine/preset/__init__.py
+++ b/voicevox_engine/preset/__init__.py
@@ -1,0 +1,1 @@
+from .PresetLoader import PresetLoader

--- a/voicevox_engine/preset/__init__.py
+++ b/voicevox_engine/preset/__init__.py
@@ -1,1 +1,1 @@
-from .PresetLoader import PresetLoader
+from .PresetLoader import PresetLoader  # noqa: F401

--- a/voicevox_engine/preset/__init__.py
+++ b/voicevox_engine/preset/__init__.py
@@ -1,1 +1,2 @@
+from .Preset import Preset  # noqa: F401
 from .PresetLoader import PresetLoader  # noqa: F401

--- a/voicevox_engine/preset/__init__.py
+++ b/voicevox_engine/preset/__init__.py
@@ -1,2 +1,7 @@
-from .Preset import Preset  # noqa: F401
-from .PresetLoader import PresetLoader  # noqa: F401
+from .Preset import Preset
+from .PresetLoader import PresetLoader
+
+__all__ = [
+    "Preset",
+    "PresetLoader",
+]


### PR DESCRIPTION
## 内容

PresetLoaderを`run.py`から移動し、モジュール化します。

- PresetLoaderクラス: `run.py` -> `voicevox_engine/preset/PresetLoader.py`
- Presetクラス: `voicevox_engine/model.py` -> `voicevox_engine/preset/Preset.py`
- TestPresetLoader: `test/test_run.py` -> `test/test_preset.py`

## 関連 Issue

ref: #119 
