### PR TITLE
リファクタリング: replace_mora_dataをSynthesisEngineに移動

### DIFF
--- a/run.py
+++ b/run.py
@@ -123,17 +123,6 @@ def generate_app(engine: SynthesisEngine) -> FastAPI:
 
     preset_loader = PresetLoader()
 
-    def replace_mora_data(
-        accent_phrases: List[AccentPhrase], speaker_id: int
-    ) -> List[AccentPhrase]:
-        return engine.replace_mora_pitch(
-            accent_phrases=engine.replace_phoneme_length(
-                accent_phrases=accent_phrases,
-                speaker_id=speaker_id,
-            ),
-            speaker_id=speaker_id,
-        )
-
     def create_accent_phrases(text: str, speaker_id: int) -> List[AccentPhrase]:
         if len(text.strip()) == 0:
             return []
@@ -142,7 +131,7 @@ def generate_app(engine: SynthesisEngine) -> FastAPI:
         if len(utterance.breath_groups) == 0:
             return []
 
-        return replace_mora_data(
+        return engine.replace_mora_data(
             accent_phrases=[
                 AccentPhrase(
                     moras=[
@@ -343,7 +332,7 @@ def generate_app(engine: SynthesisEngine) -> FastAPI:
                     status_code=400,
                     detail=ParseKanaBadRequest(err).dict(),
                 )
-            return replace_mora_data(accent_phrases=accent_phrases, speaker_id=speaker)
+            return engine.replace_mora_data(accent_phrases=accent_phrases, speaker_id=speaker)
         else:
             return create_accent_phrases(text, speaker_id=speaker)
 
@@ -354,7 +343,7 @@ def generate_app(engine: SynthesisEngine) -> FastAPI:
         summary="アクセント句から音高・音素長を得る",
     )
     def mora_data(accent_phrases: List[AccentPhrase], speaker: int):
-        return replace_mora_data(accent_phrases, speaker_id=speaker)
+        return engine.replace_mora_data(accent_phrases, speaker_id=speaker)
 
     @app.post(
         "/mora_length",

--- a/run.py
+++ b/run.py
@@ -332,7 +332,9 @@ def generate_app(engine: SynthesisEngine) -> FastAPI:
                     status_code=400,
                     detail=ParseKanaBadRequest(err).dict(),
                 )
-            return engine.replace_mora_data(accent_phrases=accent_phrases, speaker_id=speaker)
+            return engine.replace_mora_data(
+                accent_phrases=accent_phrases, speaker_id=speaker
+            )
         else:
             return create_accent_phrases(text, speaker_id=speaker)
 

--- a/voicevox_engine/synthesis_engine.py
+++ b/voicevox_engine/synthesis_engine.py
@@ -354,6 +354,19 @@ class SynthesisEngine:
 
         return accent_phrases
 
+    def replace_mora_data(
+        self,
+        accent_phrases: List[AccentPhrase],
+        speaker_id: int,
+    ) -> List[AccentPhrase]:
+        return self.replace_mora_pitch(
+            accent_phrases=self.replace_phoneme_length(
+                accent_phrases=accent_phrases,
+                speaker_id=speaker_id,
+            ),
+            speaker_id=speaker_id,
+        )
+
     def synthesis(self, query: AudioQuery, speaker_id: int):
         """
         音声合成クエリから音声合成に必要な情報を構成し、実際に音声合成を行う


### PR DESCRIPTION
## 内容

ユーティリティ関数と思われる`replace_mora_data`を`run.py`からSynthesisEngineに移動します。

## 関連 Issue

ref: #119
