### PR TITLE
手動でCIジョブを実行できるようにする

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -6,6 +6,7 @@ on:
   release:
     types:
       - created
+  workflow_dispatch:
 
 jobs:
   build-docker:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,7 @@ on:
   release:
     types:
       - created
+  workflow_dispatch:
 
 env:
   IMAGE_NAME: ${{ secrets.DOCKERHUB_USERNAME }}/voicevox_engine

--- a/.github/workflows/coverage-comment.yml
+++ b/.github/workflows/coverage-comment.yml
@@ -6,6 +6,7 @@ on:
       - test
     types:
       - completed
+  workflow_dispatch:
 
 jobs:
   comment:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,7 @@ on:
   pull_request:
     branches:
       - '**'
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
## 内容

CIの実行タイミングに`workflow_dispatch`を追加します。

リポジトリのActionsタブから個別のCIジョブのページを開くと、ブランチを指定して手動実行できるようになります。

fork先で、実行ブランチが固定されたCIを実行するのに、実行条件を書き換えるコミットを作ったり、（Releaseのテスト以外で）Releaseを作成しなくてよくなります。

## その他

気になっていたところとして、
Release時の自動ビルド実行タイミングをDraft Release作成時に実行しないように`published`にしてもいいかなと思いましたが、
自動ビルドが終わるまでDraftにしておく、のような運用もできるかもしれないと思いました。
