### PR TITLE
resampyの代わりにscipyを使用する

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -223,7 +223,6 @@ jobs:
             --include-package=anyio \
             --include-package-data=pyopenjtalk \
             --include-package-data=scipy \
-            --include-package-data=llvmlite \
             --include-data-file=../VERSION.txt=./ \
             --include-data-file=../licenses.json=./ \
             --include-data-file=../presets.yaml=./ \
@@ -232,7 +231,6 @@ jobs:
             --include-data-file=../download/core/*.bin=./ \
             --include-data-file=../download/core/metas.json=./ \
             --include-data-file=${{ env.pythonLocation }}/lib/python*/site-packages/scipy/.dylibs/*.dylib=./scipy/.dylibs/ \
-            --include-data-file=${{ env.pythonLocation }}/lib/python*/site-packages/llvmlite/binding/*.dylib=./ \
             --include-data-file=${{ env.pythonLocation }}/lib/python*/site-packages/_soundfile_data/*=./_soundfile_data/ \
             --include-data-dir=../speaker_info=./speaker_info \
             --follow-imports \
@@ -672,7 +670,6 @@ jobs:
           ln -sf "$(pwd)/download/core/metas.json" artifact/
 
           ln -sf "${{ env.PYTHON_SITE_PACKAGES_DIR }}/_soundfile_data" artifact/
-          ln -sf "${{ env.PYTHON_SITE_PACKAGES_DIR }}/llvmlite/binding/llvmlite.dll" artifact/
 
       # FIXME: versioned name may be useful; but
       # actions/download-artifact and dawidd6/download-artifact do not support

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -222,7 +222,7 @@ jobs:
             --include-package=uvicorn \
             --include-package=anyio \
             --include-package-data=pyopenjtalk \
-            --include-package-data=resampy \
+            --include-package-data=scipy \
             --include-package-data=llvmlite \
             --include-data-file=../VERSION.txt=./ \
             --include-data-file=../licenses.json=./ \
@@ -639,7 +639,7 @@ jobs:
             --include-package=uvicorn
             --include-package=anyio
             --include-package-data=pyopenjtalk
-            --include-package-data=resampy
+            --include-package-data=scipy
             --include-data-file="VERSION.txt=./"
             --include-data-file="licenses.json=./"
             --include-data-dir="speaker_info=./speaker_info"

--- a/Dockerfile
+++ b/Dockerfile
@@ -352,7 +352,7 @@ RUN <<EOF
                 --include-package=uvicorn \
                 --include-package=anyio \
                 --include-package-data=pyopenjtalk \
-                --include-package-data=resampy \
+                --include-package-data=scipy \
                 --include-data-file=/opt/voicevox_engine/VERSION.txt=./ \
                 --include-data-file=/opt/voicevox_engine/licenses.json=./ \
                 --include-data-file=/opt/voicevox_engine/presets.yaml=./ \

--- a/Dockerfile
+++ b/Dockerfile
@@ -361,7 +361,6 @@ RUN <<EOF
                 --include-data-file=/opt/voicevox_core/*.so=./ \
                 --include-data-file=/opt/voicevox_core/*.bin=./ \
                 --include-data-file=/opt/voicevox_core/metas.json=./ \
-                --include-data-file=/home/user/.local/lib/python*/site-packages/llvmlite/binding/*.so=./ \
                 --include-data-dir=/opt/voicevox_engine/speaker_info=./speaker_info \
                 --follow-imports \
                 --no-prefer-source-code \

--- a/README.md
+++ b/README.md
@@ -277,7 +277,6 @@ python -m nuitka \
     --include-data-file=C:/音声ライブラリへのパス/*.bin=./ \
     --include-data-file=C:/音声ライブラリへのパス/metas.json=./ \
     --include-data-dir=.venv/Lib/site-packages/_soundfile_data=./_soundfile_data \
-    --include-data-file=.venv-release/Lib/site-packages/llvmlite/binding/llvmlite.dll=./ \
     --include-data-dir=speaker_info=./speaker_info \
     --msvc=14.2 \
     --follow-imports \

--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ python -m nuitka \
     --include-package=uvicorn \
     --include-package=anyio \
     --include-package-data=pyopenjtalk \
-    --include-package-data=resampy \
+    --include-package-data=scipy \
     --include-data-file=VERSION.txt=./ \
     --include-data-file=licenses.json=./ \
     --include-data-file=presets.yaml=./ \

--- a/generate_licenses.py
+++ b/generate_licenses.py
@@ -142,11 +142,6 @@ def generate_licenses() -> List[License]:
                     "https://raw.githubusercontent.com/soimort/python-romkan/master/LICENSE"
                 ) as res:
                     license.text = res.read().decode()
-            elif license.name.lower() == "resampy":
-                with urllib.request.urlopen(
-                    "https://raw.githubusercontent.com/bmcfee/resampy/master/LICENSE"
-                ) as res:
-                    license.text = res.read().decode()
             else:
                 # ライセンスがpypiに無い
                 raise Exception(f"No License info provided for {license.name}")

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -33,19 +33,13 @@ importlib-metadata==4.8.1
     # via
     #   click
     #   pep517
-llvmlite==0.37.0
-    # via numba
 nuitka==0.6.17.4
     # via -r requirements-dev.in
-numba==0.54.1
-    # via resampy
 numpy==1.20.0
     # via
     #   -r requirements.in
-    #   numba
     #   pyopenjtalk
     #   pyworld
-    #   resampy
     #   scipy
 pep517==0.12.0
     # via pip-tools
@@ -67,15 +61,12 @@ pyworld==0.3.0
     # via -r requirements.in
 pyyaml==6.0
     # via -r requirements.in
-resampy==0.2.2
-    # via -r requirements.in
 scipy==1.7.1
-    # via resampy
+    # via -r requirements.in
 six==1.16.0
     # via
     #   pyopenjtalk
     #   python-multipart
-    #   resampy
 sniffio==1.2.0
     # via anyio
 soundfile==0.10.3.post1

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -77,8 +77,6 @@ iniconfig==1.1.1
     # via pytest
 isort==5.1.4
     # via pysen
-llvmlite==0.37.0
-    # via numba
 mccabe==0.6.1
     # via flake8
 mypy==0.790
@@ -87,15 +85,11 @@ mypy-extensions==0.4.3
     # via
     #   black
     #   mypy
-numba==0.54.1
-    # via resampy
 numpy==1.20.0
     # via
     #   -r requirements.in
-    #   numba
     #   pyopenjtalk
     #   pyworld
-    #   resampy
     #   scipy
 packaging==21.0
     # via pytest
@@ -131,15 +125,12 @@ regex==2021.10.23
     # via black
 requests==2.26.0
     # via coveralls
-resampy==0.2.2
-    # via -r requirements.in
 scipy==1.7.1
-    # via resampy
+    # via -r requirements.in
 six==1.16.0
     # via
     #   pyopenjtalk
     #   python-multipart
-    #   resampy
 smmap==5.0.0
     # via gitdb
 sniffio==1.2.0
@@ -177,6 +168,3 @@ uvicorn==0.15.0
     # via -r requirements.in
 zipp==3.6.0
     # via importlib-metadata
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools

--- a/requirements.in
+++ b/requirements.in
@@ -1,10 +1,10 @@
-numpy==1.20 # ver 1.20 for resampy
+numpy
 fastapi
 python-multipart
 uvicorn
 aiofiles
 soundfile
-resampy
+scipy
 PyYAML
 pyworld
 git+https://github.com/Hiroshiba/pyopenjtalk@69e5f354634f98098113f9cac5a6ea736443f9c9#egg=pyopenjtalk

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,17 +28,11 @@ idna==3.3
     # via anyio
 importlib-metadata==4.8.1
     # via click
-llvmlite==0.37.0
-    # via numba
-numba==0.54.1
-    # via resampy
 numpy==1.20.0
     # via
     #   -r requirements.in
-    #   numba
     #   pyopenjtalk
     #   pyworld
-    #   resampy
     #   scipy
 pycparser==2.20
     # via cffi
@@ -52,15 +46,12 @@ pyworld==0.3.0
     # via -r requirements.in
 pyyaml==6.0
     # via -r requirements.in
-resampy==0.2.2
-    # via -r requirements.in
 scipy==1.7.1
-    # via resampy
+    # via -r requirements.in
 six==1.16.0
     # via
     #   pyopenjtalk
     #   python-multipart
-    #   resampy
 sniffio==1.2.0
     # via anyio
 soundfile==0.10.3.post1
@@ -79,6 +70,3 @@ uvicorn==0.15.0
     # via -r requirements.in
 zipp==3.6.0
     # via importlib-metadata
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools

--- a/voicevox_engine/dev/core/mock.py
+++ b/voicevox_engine/dev/core/mock.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List
 
 import numpy as np
 from pyopenjtalk import tts
-from resampy import resample
+from scipy.signal import resample
 
 DUMMY_TEXT = "これはダミーのテキストです"
 
@@ -64,9 +64,7 @@ def decode_forward(length: int, **kwargs: Dict[str, Any]) -> np.ndarray:
     wave, sr = tts(DUMMY_TEXT)
     wave = resample(
         wave.astype("int16"),
-        sr,
-        24000,
-        filter="kaiser_fast",
+        24000 * len(wave) // 48000,
     )
     return wave
 

--- a/voicevox_engine/dev/core/mock.py
+++ b/voicevox_engine/dev/core/mock.py
@@ -53,8 +53,6 @@ def decode_forward(length: int, **kwargs: Dict[str, Any]) -> np.ndarray:
         dtype=np.float64, 16 bit, mono 48000 Hz
 
         # resampleの説明
-        本来はfloat64の入力でも問題ないのかと思われたが、実際には出力が音割れひどかった。
-        対策として、あらかじめint16に型変換しておくと、期待通りの結果になった。
         非モックdecode_forwardと合わせるために、出力を24kHzに変換した。
     """
     logger = getLogger("uvicorn")  # FastAPI / Uvicorn 内からの利用のため

--- a/voicevox_engine/dev/synthesis_engine/mock.py
+++ b/voicevox_engine/dev/synthesis_engine/mock.py
@@ -114,8 +114,6 @@ class SynthesisEngine:
         dtype=np.float64, 16 bit, mono 48000 Hz
 
         # resampleの説明
-        本来はfloat64の入力でも問題ないのかと思われたが、実際には出力が音割れひどかった。
-        対策として、あらかじめint16に型変換しておくと、期待通りの結果になった。
         非モック実装（decode_forward）と合わせるために、出力を24kHzに変換した。
         """
         logger = getLogger("uvicorn")  # FastAPI / Uvicorn 内からの利用のため

--- a/voicevox_engine/dev/synthesis_engine/mock.py
+++ b/voicevox_engine/dev/synthesis_engine/mock.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, List
 
 import numpy as np
 from pyopenjtalk import tts
-from resampy import resample
+from scipy.signal import resample
 
 from voicevox_engine.model import AccentPhrase, AudioQuery
 from voicevox_engine.synthesis_engine import to_flatten_moras
@@ -123,8 +123,6 @@ class SynthesisEngine:
         wave, sr = tts(text)
         wave = resample(
             wave.astype("int16"),
-            sr,
-            24000,
-            filter="kaiser_fast",
+            24000 * len(wave) // 48000,
         )
         return wave.astype("int16")

--- a/voicevox_engine/synthesis_engine.py
+++ b/voicevox_engine/synthesis_engine.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from typing import List, Optional, Tuple
 
 import numpy
-import resampy
+from scipy.signal import resample
 
 from voicevox_engine.acoustic_feature_extractor import OjtPhoneme, SamplingData
 from voicevox_engine.model import AccentPhrase, AudioQuery, Mora
@@ -480,11 +480,9 @@ class SynthesisEngine:
 
         # 出力サンプリングレートがデフォルト(decode forwarderによるもの、24kHz)でなければ、それを適用する
         if query.outputSamplingRate != self.default_sampling_rate:
-            wave = resampy.resample(
+            wave = resample(
                 wave,
-                self.default_sampling_rate,
-                query.outputSamplingRate,
-                filter="kaiser_fast",
+                query.outputSamplingRate * len(wave) // self.default_sampling_rate,
             )
 
         # ステレオ変換


### PR DESCRIPTION
## 内容
現在はサンプリングレートの変更にresampyを使用していますが、その代わりにscipyを使用します。
resampyは内部でnumbaを使用しており、nuitkaビルドの成果物でエラーが発生していました。
尚、scipyはresampyが使用しているので新たな必要モジュールはありません。
resampy、numba、llvmliteへの依存が無くなります。
音質に関しては向上はしていないと感じました。（自分の耳では）

## 関連 Issue
close #167 
- #167 

## その他
テスト用リリースです。
https://github.com/takana-v/voicevox_engine/releases/tag/build-test6